### PR TITLE
Fix: support for Python 3.11

### DIFF
--- a/.github/workflows/pytest-docker.yml
+++ b/.github/workflows/pytest-docker.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        image: [ "python-3.9", "python-3.10", "ubuntu-20.04", "ubuntu-22.04" ]
+        image: [ "python-3.9", "python-3.10", "python-3.11", "ubuntu-20.04", "ubuntu-22.04" ]
     runs-on: ubuntu-22.04
 
     steps:

--- a/docker/python-3.11.dockerfile
+++ b/docker/python-3.11.dockerfile
@@ -20,7 +20,7 @@ RUN pip install --upgrade pip wheel twine
 
 # Preinstall dependencies for faster steps
 RUN pip install --upgrade secp256k1 coincurve aiohttp eciespy python-magic typer
-RUN pip install --upgrade 'aleph-message~=0.3.1' eth_account pynacl base58
+RUN pip install --upgrade 'aleph-message~=0.3.1' pynacl base58
 RUN pip install --upgrade pytest pytest-cov pytest-asyncio mypy types-setuptools pytest-asyncio fastapi httpx requests
 
 WORKDIR /opt/aleph-sdk-python/

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,8 @@ install_requires =
     typer
     aleph-message~=0.3.1
     eth_account>=0.4.0
+    # Required to fix a dependency issue with parsimonious and Python3.11
+    eth_abi==4.0.0b2; python_version>="3.11"
     python-magic
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
@@ -86,6 +88,8 @@ nuls2 =
     nuls2-python@git+https://github.com/odesenfans/nuls2-python.git@fda2ba4a5f9397f4f84cfee738942c4a15f88840
 ethereum =
     eth_account>=0.4.0
+    # Required to fix a dependency issue with parsimonious and Python3.11
+    eth_abi==4.0.0b2; python_version>="3.11"
 polkadot =
     substrate-interface==1.3.4
 cosmos =

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,8 +82,8 @@ mqtt =
     certifi
     Click
 nuls2 =
-    nuls2-python; python_version<"3.11"
-    nuls2-python@git+https://github.com/odesenfans/nuls2-python.git@fda2ba4a5f9397f4f84cfee738942c4a15f88840; python_version>="3.11"
+    # use the branch with support for Python 3.11
+    nuls2-python@git+https://github.com/odesenfans/nuls2-python.git@fda2ba4a5f9397f4f84cfee738942c4a15f88840
 ethereum =
     eth_account>=0.4.0
 polkadot =

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ testing =
     # httpx is required in tests by fastapi.testclient
     httpx
     requests
-    aleph-pytezos==0.1.0
+    aleph-pytezos==0.1.1
     types-certifi
     types-setuptools
     black
@@ -95,7 +95,7 @@ solana =
     base58
 tezos =
     pynacl
-    aleph-pytezos==0.1.0
+    aleph-pytezos==0.1.1
 docs =
     sphinxcontrib-plantuml
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,8 @@ mqtt =
     certifi
     Click
 nuls2 =
-    nuls2-python
+    nuls2-python; python_version<"3.11"
+    nuls2-python@git+https://github.com/odesenfans/nuls2-python.git@fda2ba4a5f9397f4f84cfee738942c4a15f88840; python_version>="3.11"
 ethereum =
     eth_account>=0.4.0
 polkadot =

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,9 +31,11 @@ package_dir =
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires = 
-    coincurve
+    coincurve; python_version<"3.11"
+    coincurve>=17.0.0; python_version>="3.11"   # Technically, this should be >=18.0.0 but there is a conflict with eciespy
     aiohttp>=3.8.3
-    eciespy
+    eciespy; python_version<"3.11"
+    eciespy>=0.3.13; python_version>="3.11"
     typing_extensions
     typer
     aleph-message~=0.3.1


### PR DESCRIPTION
Problem: some dependencies only support Python 3.11 in the latest releases. We do not want to restrict the version range for users of older Python versions.

Solution: specify loose versions for Python<3.11 and the correct ones for Python 3.11.