### PR TITLE
Add metadata parameter to create_program()

### DIFF
--- a/src/aleph/sdk/client.py
+++ b/src/aleph/sdk/client.py
@@ -377,6 +377,7 @@ class AuthenticatedUserSessionSync(UserSessionSync):
         encoding: Encoding = Encoding.zip,
         volumes: Optional[List[Mapping]] = None,
         subscriptions: Optional[List[Mapping]] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
     ) -> Tuple[ProgramMessage, MessageStatus]:
         return self._wrap(
             self.async_session.create_program,
@@ -395,6 +396,7 @@ class AuthenticatedUserSessionSync(UserSessionSync):
             encoding=encoding,
             volumes=volumes,
             subscriptions=subscriptions,
+            metadata=metadata,
         )
 
     def forget(
@@ -1170,6 +1172,7 @@ class AuthenticatedAlephClient(AlephClient):
         encoding: Encoding = Encoding.zip,
         volumes: Optional[List[Mapping]] = None,
         subscriptions: Optional[List[Mapping]] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
     ) -> Tuple[ProgramMessage, MessageStatus]:
         """
         Post a (create) PROGRAM message.
@@ -1243,6 +1246,7 @@ class AuthenticatedAlephClient(AlephClient):
                 },
                 "volumes": volumes,
                 "time": time.time(),
+                "metadata": metadata,
             }
         )
 

--- a/tests/unit/test_asynchronous.py
+++ b/tests/unit/test_asynchronous.py
@@ -130,6 +130,7 @@ async def test_create_program(mock_session_with_post_success):
             entrypoint="main:app",
             runtime="facefacefacefacefacefacefacefacefacefacefacefacefacefacefaceface",
             channel="TEST",
+            metadata={"tags": ["test"]},
         )
 
     assert mock_session_with_post_success.http_session.post.called_once


### PR DESCRIPTION
To allow programmatic deployment of VMs with metadata