### PR TITLE
Rename project and UserSession

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 # .coveragerc to control coverage.py
 [run]
 branch = True
-source = aleph_client
+source = aleph.sdk
 # omit = bad_file.py
 
 [paths]

--- a/examples/httpgateway.py
+++ b/examples/httpgateway.py
@@ -7,7 +7,7 @@ from aiohttp import web
 
 from aleph.sdk.chains.common import get_fallback_private_key
 from aleph.sdk.chains.ethereum import ETHAccount
-from aleph.sdk.user_session import AuthenticatedUserSession
+from aleph.sdk.client import AuthenticatedAlephClient
 
 app = web.Application()
 routes = web.RouteTableDef()
@@ -32,7 +32,7 @@ async def source_post(request):
             return web.json_response(
                 {"status": "error", "message": "unauthorized secret"}
             )
-    async with AuthenticatedUserSession(
+    async with AuthenticatedAlephClient(
         account=app["account"], api_server="https://api2.aleph.im"
     ) as session:
         message, _status = await session.create_post(

--- a/examples/metrics.py
+++ b/examples/metrics.py
@@ -11,12 +11,9 @@ import psutil
 from aleph_message.models import AlephMessage
 
 from aleph.sdk.chains.ethereum import get_fallback_account
+from aleph.sdk.client import AuthenticatedAlephClient, AuthenticatedUserSessionSync
 from aleph.sdk.conf import settings
 from aleph.sdk.types import MessageStatus
-from aleph.sdk.user_session import (
-    AuthenticatedUserSession,
-    AuthenticatedUserSessionSync,
-)
 
 
 def get_sysinfo():
@@ -73,7 +70,7 @@ def collect_metrics():
 
 def main():
     account = get_fallback_account()
-    with AuthenticatedUserSession(
+    with AuthenticatedAlephClient(
         account=account, api_server=settings.API_HOST
     ) as session:
         while True:

--- a/examples/mqtt.py
+++ b/examples/mqtt.py
@@ -10,8 +10,8 @@ import click
 
 from aleph.sdk.chains.common import get_fallback_private_key
 from aleph.sdk.chains.ethereum import ETHAccount
+from aleph.sdk.client import AuthenticatedAlephClient
 from aleph.sdk.conf import settings
-from aleph.sdk.user_session import AuthenticatedUserSession
 
 
 def get_input_data(value):
@@ -27,7 +27,7 @@ def get_input_data(value):
 
 
 def send_metrics(account, metrics):
-    with AuthenticatedUserSession(
+    with AuthenticatedAlephClient(
         account=account, api_server=settings.API_HOST
     ) as session:
         return session.create_aggregate(
@@ -100,7 +100,7 @@ async def gateway(
         if not userdata["received"]:
             await client.reconnect()
 
-        async with AuthenticatedUserSession(
+        async with AuthenticatedAlephClient(
             account=account, api_server=settings.API_HOST
         ) as session:
             for key, value in state.items():

--- a/examples/store.py
+++ b/examples/store.py
@@ -5,9 +5,9 @@ from aleph_message.models import StoreMessage
 
 from aleph.sdk.chains.common import get_fallback_private_key
 from aleph.sdk.chains.ethereum import ETHAccount
+from aleph.sdk.client import AuthenticatedAlephClient
 from aleph.sdk.conf import settings
 from aleph.sdk.types import MessageStatus
-from aleph.sdk.user_session import AuthenticatedUserSession
 
 DEFAULT_SERVER = "https://api2.aleph.im"
 
@@ -23,7 +23,7 @@ async def print_output_hash(message: StoreMessage, status: MessageStatus):
 
 
 async def do_upload(account, engine, channel, filename=None, file_hash=None):
-    async with AuthenticatedUserSession(
+    async with AuthenticatedAlephClient(
         account=account, api_server=settings.API_HOST
     ) as session:
         print(filename, account.get_address())

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,11 +98,9 @@ docs =
 
 [options.entry_points]
 # Add here console scripts like:
-console_scripts =
-     aleph = aleph_client.__main__:app
 # For example:
 # console_scripts =
-#     fibonacci = aleph_client.skeleton:run
+#     fibonacci = aleph.sdk.skeleton:run
 # And any other entry points, for example:
 # pyscaffold.cli =
 #     awesome = pyscaffoldext.awesome.extension:AwesomeExtension
@@ -118,7 +116,7 @@ extras = True
 # e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml
 # in order to write a coverage file that can be read by Jenkins.
 addopts =
-    --cov aleph_client --cov-report term-missing
+    --cov aleph.sdk --cov-report term-missing
     --verbose
 norecursedirs =
     dist
@@ -160,4 +158,4 @@ profile = black
 # PyScaffold's parameters when the project was created.
 # This will be used when updating. Do not change!
 version = 3.2.1
-package = aleph_client
+package = aleph.sdk

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-    Setup file for aleph_client.
+    Setup file for aleph.sdk
     Use setup.cfg to configure your project.
 
     This file was generated with PyScaffold 3.2.1.

--- a/src/aleph/sdk/__init__.py
+++ b/src/aleph/sdk/__init__.py
@@ -1,6 +1,6 @@
 from pkg_resources import DistributionNotFound, get_distribution
 
-from aleph.sdk.user_session import AuthenticatedUserSession, UserSession
+from aleph.sdk.client import AlephClient, AuthenticatedAlephClient
 
 try:
     # Change here if project is renamed and does not equal the package name
@@ -11,4 +11,4 @@ except DistributionNotFound:
 finally:
     del get_distribution, DistributionNotFound
 
-__all__ = ["AuthenticatedUserSession", "UserSession"]
+__all__ = ["AlephClient", "AuthenticatedAlephClient"]

--- a/tests/integration/itest_aggregates.py
+++ b/tests/integration/itest_aggregates.py
@@ -3,8 +3,8 @@ from typing import Dict
 
 import pytest
 
+from aleph.sdk.client import AuthenticatedAlephClient
 from aleph.sdk.types import Account
-from aleph.sdk.user_session import AuthenticatedUserSession
 from tests.integration.toolkit import try_until
 
 from .config import REFERENCE_NODE, TARGET_NODE
@@ -18,7 +18,7 @@ async def create_aggregate_on_target(
     receiver_node: str,
     channel="INTEGRATION_TESTS",
 ):
-    async with AuthenticatedUserSession(
+    async with AuthenticatedAlephClient(
         account=account, api_server=emitter_node
     ) as tx_session:
         aggregate_message, message_status = await tx_session.create_aggregate(
@@ -38,7 +38,7 @@ async def create_aggregate_on_target(
     assert aggregate_message.content.address == account.get_address()
     assert aggregate_message.content.content == content
 
-    async with AuthenticatedUserSession(
+    async with AuthenticatedAlephClient(
         account=account, api_server=receiver_node
     ) as rx_session:
         aggregate_from_receiver = await try_until(

--- a/tests/integration/itest_forget.py
+++ b/tests/integration/itest_forget.py
@@ -2,8 +2,8 @@ from typing import Callable, Dict
 
 import pytest
 
+from aleph.sdk.client import AuthenticatedAlephClient
 from aleph.sdk.types import Account
-from aleph.sdk.user_session import AuthenticatedUserSession
 
 from .config import REFERENCE_NODE, TARGET_NODE, TEST_CHANNEL
 from .toolkit import try_until
@@ -17,7 +17,7 @@ async def create_and_forget_post(
         condition: Callable[[Dict], bool],
         timeout: int = 5,
     ):
-        async with AuthenticatedUserSession(
+        async with AuthenticatedAlephClient(
             account=account, api_server=receiver_node
         ) as rx_session:
             return await try_until(
@@ -27,7 +27,7 @@ async def create_and_forget_post(
                 hashes=[item_hash],
             )
 
-    async with AuthenticatedUserSession(
+    async with AuthenticatedAlephClient(
         account=account, api_server=emitter_node
     ) as tx_session:
         post_message, message_status = await tx_session.create_post(
@@ -46,7 +46,7 @@ async def create_and_forget_post(
 
     post_hash = post_message.item_hash
     reason = "This well thought-out content offends me!"
-    async with AuthenticatedUserSession(
+    async with AuthenticatedAlephClient(
         account=account, api_server=emitter_node
     ) as tx_session:
         forget_message, forget_status = await tx_session.forget(
@@ -103,7 +103,7 @@ async def test_forget_a_forget_message(fixture_account):
 
     # TODO: this test should be moved to the PyAleph API tests, once a framework is in place.
     post_hash = await create_and_forget_post(fixture_account, TARGET_NODE, TARGET_NODE)
-    async with AuthenticatedUserSession(
+    async with AuthenticatedAlephClient(
         account=fixture_account, api_server=TARGET_NODE
     ) as session:
         get_post_response = await session.get_posts(hashes=[post_hash])

--- a/tests/integration/itest_posts.py
+++ b/tests/integration/itest_posts.py
@@ -1,7 +1,7 @@
 import pytest
 from aleph_message.models import MessagesResponse
 
-from aleph.sdk.user_session import AuthenticatedUserSession
+from aleph.sdk.client import AuthenticatedAlephClient
 from tests.integration.toolkit import try_until
 
 from .config import REFERENCE_NODE, TARGET_NODE
@@ -13,7 +13,7 @@ async def create_message_on_target(
     """
     Create a POST message on the target node, then fetch it from the reference node.
     """
-    async with AuthenticatedUserSession(
+    async with AuthenticatedAlephClient(
         account=fixture_account, api_server=emitter_node
     ) as tx_session:
         post_message, message_status = await tx_session.create_post(
@@ -25,7 +25,7 @@ async def create_message_on_target(
     def response_contains_messages(response: MessagesResponse) -> bool:
         return len(response.messages) > 0
 
-    async with AuthenticatedUserSession(
+    async with AuthenticatedAlephClient(
         account=fixture_account, api_server=receiver_node
     ) as rx_session:
         responses = await try_until(

--- a/tests/unit/test_asynchronous.py
+++ b/tests/unit/test_asynchronous.py
@@ -10,14 +10,14 @@ from aleph_message.models import (
     StoreMessage,
 )
 
+from aleph.sdk.client import AuthenticatedAlephClient
 from aleph.sdk.types import Account, MessageStatus, StorageEnum
-from aleph.sdk.user_session import AuthenticatedUserSession
 
 
 @pytest.fixture
 def mock_session_with_post_success(
     ethereum_account: Account,
-) -> AuthenticatedUserSession:
+) -> AuthenticatedAlephClient:
     class MockResponse:
         def __init__(self, sync: bool):
             self.sync = sync
@@ -48,12 +48,12 @@ def mock_session_with_post_success(
         sync=kwargs.get("sync", False)
     )
 
-    user_session = AuthenticatedUserSession(
+    client = AuthenticatedAlephClient(
         account=ethereum_account, api_server="http://localhost"
     )
-    user_session.http_session = http_session
+    client.http_session = http_session
 
-    return user_session
+    return client
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_asynchronous_get.py
+++ b/tests/unit/test_asynchronous_get.py
@@ -5,11 +5,11 @@ from unittest.mock import AsyncMock
 import pytest
 from aleph_message.models import MessagesResponse, MessageType
 
+from aleph.sdk.client import AlephClient
 from aleph.sdk.conf import settings
-from aleph.sdk.user_session import UserSession
 
 
-def make_mock_session(get_return_value: Dict[str, Any]) -> UserSession:
+def make_mock_session(get_return_value: Dict[str, Any]) -> AlephClient:
     class MockResponse:
         async def __aenter__(self):
             return self
@@ -30,10 +30,10 @@ def make_mock_session(get_return_value: Dict[str, Any]) -> UserSession:
 
     http_session = MockHttpSession()
 
-    user_session = UserSession(api_server="http://localhost")
-    user_session.http_session = http_session
+    client = AlephClient(api_server="http://localhost")
+    client.http_session = http_session
 
-    return user_session
+    return client
 
 
 @pytest.mark.asyncio
@@ -65,7 +65,7 @@ async def test_fetch_aggregates():
 
 @pytest.mark.asyncio
 async def test_get_posts():
-    async with UserSession(api_server=settings.API_HOST) as session:
+    async with AlephClient(api_server=settings.API_HOST) as session:
         response: MessagesResponse = await session.get_messages(
             message_type=MessageType.post,
         )
@@ -78,7 +78,7 @@ async def test_get_posts():
 
 @pytest.mark.asyncio
 async def test_get_messages():
-    async with UserSession(api_server=settings.API_HOST) as session:
+    async with AlephClient(api_server=settings.API_HOST) as session:
         response: MessagesResponse = await session.get_messages(
             pagination=2,
         )

--- a/tests/unit/test_synchronous_get.py
+++ b/tests/unit/test_synchronous_get.py
@@ -1,11 +1,11 @@
 from aleph_message.models import MessagesResponse, MessageType
 
+from aleph.sdk.client import AlephClient
 from aleph.sdk.conf import settings
-from aleph.sdk.user_session import UserSession
 
 
 def test_get_posts():
-    with UserSession(api_server=settings.API_HOST) as session:
+    with AlephClient(api_server=settings.API_HOST) as session:
         response: MessagesResponse = session.get_messages(
             pagination=2,
             message_type=MessageType.post,


### PR DESCRIPTION
Renames `aleph_client` into `aleph.sdk` and `(Authenticated)UserSession` into `(Authenticated)AlephClient`.

Do not squash.