### PR TITLE
Feature: Signature verification for Solana and Ethereum messages

### DIFF
--- a/src/aleph/sdk/chains/cosmos.py
+++ b/src/aleph/sdk/chains/cosmos.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import json
+from typing import Union
 
 import ecdsa
 from cosmospy._wallet import privkey_to_address, privkey_to_pubkey
@@ -80,3 +81,12 @@ class CSDKAccount(BaseAccount):
 
 def get_fallback_account(hrp=DEFAULT_HRP):
     return CSDKAccount(private_key=get_fallback_private_key(), hrp=hrp)
+
+
+def verify_signature(
+    signature: Union[bytes, str],
+    public_key: Union[bytes, str],
+    message: Union[bytes, str],
+) -> bool:
+    """TODO: Implement this"""
+    raise NotImplementedError("Not implemented yet")

--- a/src/aleph/sdk/chains/ethereum.py
+++ b/src/aleph/sdk/chains/ethereum.py
@@ -75,5 +75,5 @@ def verify_signature(
             return True
         else:
             return False
-    except Exception as e:
+    except Exception:
         return False

--- a/src/aleph/sdk/chains/ethereum.py
+++ b/src/aleph/sdk/chains/ethereum.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from eth_account import Account
 from eth_account.messages import encode_defunct
@@ -41,3 +41,39 @@ class ETHAccount(BaseAccount):
 
 def get_fallback_account(path: Optional[Path] = None) -> ETHAccount:
     return ETHAccount(private_key=get_fallback_private_key(path=path))
+
+
+def verify_signature(
+    signature: Union[bytes, str],
+    public_key: Union[bytes, str],
+    message: Union[bytes, str],
+) -> bool:
+    """
+    Verifies a signature.
+    Args:
+        signature: The signature to verify. Can be a hex encoded string or bytes.
+        public_key: The sender's public key to use for verification. Can be a checksummed, hex encoded string or bytes.
+        message: The message to verify. Can be an utf-8 string or bytes.
+    """
+    if isinstance(signature, str):
+        if signature.startswith("0x"):
+            signature = signature[2:]
+        signature = bytes.fromhex(signature)
+    else:
+        if signature.startswith(b"0x"):
+            signature = signature[2:]
+        signature = bytes.fromhex(signature.decode("utf-8"))
+    if isinstance(public_key, bytes):
+        public_key = "0x" + public_key.hex()
+    if isinstance(message, bytes):
+        message = message.decode("utf-8")
+
+    message_hash = encode_defunct(text=message)
+    try:
+        address = Account.recover_message(message_hash, signature=signature)
+        if address == public_key:
+            return True
+        else:
+            return False
+    except Exception as e:
+        return False

--- a/src/aleph/sdk/chains/nuls1.py
+++ b/src/aleph/sdk/chains/nuls1.py
@@ -4,7 +4,7 @@ import hashlib
 import logging
 import struct
 from binascii import hexlify, unhexlify
-from typing import Optional
+from typing import Optional, Union
 
 from coincurve.keys import PrivateKey, PublicKey
 
@@ -324,3 +324,12 @@ class NULSAccount(BaseAccount):
 
 def get_fallback_account(chain_id=8964):
     return NULSAccount(private_key=get_fallback_private_key(), chain_id=chain_id)
+
+
+def verify_signature(
+    signature: Union[bytes, str],
+    public_key: Union[bytes, str],
+    message: Union[bytes, str],
+) -> bool:
+    """TODO: Implement this"""
+    raise NotImplementedError("Not implemented yet")

--- a/src/aleph/sdk/chains/nuls2.py
+++ b/src/aleph/sdk/chains/nuls2.py
@@ -1,4 +1,5 @@
 import base64
+from typing import Union
 
 from nuls2.model.data import (
     NETWORKS,
@@ -60,3 +61,12 @@ class NULSAccount(BaseAccount):
 def get_fallback_account(chain_id=1):
     acc = NULSAccount(private_key=get_fallback_private_key(), chain_id=chain_id)
     return acc
+
+
+def verify_signature(
+    signature: Union[bytes, str],
+    public_key: Union[bytes, str],
+    message: Union[bytes, str],
+) -> bool:
+    """TODO: Implement this"""
+    raise NotImplementedError("Not implemented yet")

--- a/src/aleph/sdk/chains/sol.py
+++ b/src/aleph/sdk/chains/sol.py
@@ -4,11 +4,12 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 
 import base58
-from nacl.exceptions import BadSignatureError
+from nacl.exceptions import BadSignatureError as NaclBadSignatureError
 from nacl.public import PrivateKey, SealedBox
 from nacl.signing import SigningKey, VerifyKey
 
 from ..conf import settings
+from ..exceptions import BadSignatureError
 from .common import BaseAccount, get_verification_buffer
 
 
@@ -88,13 +89,15 @@ def verify_signature(
     signature: Union[bytes, str],
     public_key: Union[bytes, str],
     message: Union[bytes, str],
-) -> bool:
+):
     """
     Verifies a signature.
     Args:
         signature: The signature to verify. Can be a base58 encoded string or bytes.
         public_key: The public key to use for verification. Can be a base58 encoded string or bytes.
         message: The message to verify. Can be an utf-8 string or bytes.
+    Raises:
+        BadSignatureError: If the signature is invalid.
     """
     if isinstance(signature, str):
         signature = base58.b58decode(signature)
@@ -104,6 +107,5 @@ def verify_signature(
         public_key = base58.b58decode(public_key)
     try:
         VerifyKey(public_key).verify(message, signature)
-        return True
-    except BadSignatureError:
-        return False
+    except NaclBadSignatureError as e:
+        raise BadSignatureError from e

--- a/src/aleph/sdk/chains/substrate.py
+++ b/src/aleph/sdk/chains/substrate.py
@@ -1,4 +1,5 @@
 import json
+from typing import Union
 
 from substrateinterface import Keypair
 
@@ -45,3 +46,12 @@ def get_fallback_mnemonics():
             prvfile.write(mnemonic)
 
     return mnemonic
+
+
+def verify_signature(
+    signature: Union[bytes, str],
+    public_key: Union[bytes, str],
+    message: Union[bytes, str],
+) -> bool:
+    """TODO: Implement this"""
+    raise NotImplementedError("Not implemented yet")

--- a/src/aleph/sdk/chains/tezos.py
+++ b/src/aleph/sdk/chains/tezos.py
@@ -55,5 +55,17 @@ def verify_signature(
     public_key: Union[bytes, str],
     message: Union[bytes, str],
 ) -> bool:
-    """TODO: Implement this"""
-    raise NotImplementedError("Not implemented yet")
+    """
+    Verify a signature using the public key (hash) of a tezos account.
+
+    Note: It requires the public key hash (sp, p2, ed-prefix), not the address (tz1, tz2 prefix)!
+    Args:
+        signature: The signature to verify. Can be a base58 encoded string or bytes.
+        public_key: The public key (hash) of the account. Can be a base58 encoded string or bytes.
+        message: The message that was signed. Is a sequence of bytes in raw format or hexadecimal notation.
+    """
+    key = Key.from_encoded_key(public_key)
+    try:
+        return key.verify(signature, message)
+    except ValueError:
+        return False

--- a/src/aleph/sdk/chains/tezos.py
+++ b/src/aleph/sdk/chains/tezos.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from aleph_pytezos.crypto.key import Key
 from nacl.public import SealedBox
@@ -48,3 +48,12 @@ class TezosAccount(BaseAccount):
 
 def get_fallback_account(path: Optional[Path] = None) -> TezosAccount:
     return TezosAccount(private_key=get_fallback_private_key(path=path))
+
+
+def verify_signature(
+    signature: Union[bytes, str],
+    public_key: Union[bytes, str],
+    message: Union[bytes, str],
+) -> bool:
+    """TODO: Implement this"""
+    raise NotImplementedError("Not implemented yet")

--- a/src/aleph/sdk/exceptions.py
+++ b/src/aleph/sdk/exceptions.py
@@ -34,3 +34,11 @@ class InvalidMessageError(BroadcastError):
     """
 
     pass
+
+
+class BadSignatureError(Exception):
+    """
+    The signature of a message is invalid.
+    """
+
+    pass

--- a/tests/unit/test_chain_ethereum.py
+++ b/tests/unit/test_chain_ethereum.py
@@ -48,12 +48,19 @@ async def test_verify_signature(ethereum_account):
     account = ethereum_account
 
     message = asdict(
-        Message("ETH", account.get_address(), "POST", "0b63f44cdab8eec51d7f6f120787962609b0da8729b6020b8c45ca0748f674de")
+        Message(
+            "ETH",
+            account.get_address(),
+            "POST",
+            "SomeHash",
+        )
     )
     await account.sign_message(message)
     assert message["signature"]
 
-    assert verify_signature(message["signature"], message["sender"], get_verification_buffer(message))
+    assert verify_signature(
+        message["signature"], message["sender"], get_verification_buffer(message)
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_chain_ethereum.py
+++ b/tests/unit/test_chain_ethereum.py
@@ -4,7 +4,8 @@ from tempfile import NamedTemporaryFile
 
 import pytest
 
-from aleph.sdk.chains.ethereum import get_fallback_account
+from aleph.sdk.chains.common import get_verification_buffer
+from aleph.sdk.chains.ethereum import get_fallback_account, verify_signature
 
 
 @dataclass
@@ -40,6 +41,19 @@ async def test_ETHAccount(ethereum_account):
     pubkey = account.get_public_key()
     assert type(pubkey) == str
     assert len(pubkey) == 68
+
+
+@pytest.mark.asyncio
+async def test_verify_signature(ethereum_account):
+    account = ethereum_account
+
+    message = asdict(
+        Message("ETH", account.get_address(), "POST", "0b63f44cdab8eec51d7f6f120787962609b0da8729b6020b8c45ca0748f674de")
+    )
+    await account.sign_message(message)
+    assert message["signature"]
+
+    assert verify_signature(message["signature"], message["sender"], get_verification_buffer(message))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_chain_solana.py
+++ b/tests/unit/test_chain_solana.py
@@ -75,11 +75,18 @@ async def test_decrypt_curve25516(solana_account):
 @pytest.mark.asyncio
 async def test_verify_signature(solana_account):
     message = asdict(
-        Message("SOL", solana_account.get_address(), "POST", "0b63f44cdab8eec51d7f6f120787962609b0da8729b6020b8c45ca0748f674de")
+        Message(
+            "SOL",
+            solana_account.get_address(),
+            "POST",
+            "SomeHash",
+        )
     )
     await solana_account.sign_message(message)
     assert message["signature"]
     raw_signature = json.loads(message["signature"])["signature"]
     assert type(raw_signature) == str
 
-    assert verify_signature(raw_signature, message["sender"], get_verification_buffer(message))
+    assert verify_signature(
+        raw_signature, message["sender"], get_verification_buffer(message)
+    )


### PR DESCRIPTION
Problem: Users cannot verify signatures

Solution: Implement verify_signature() functions for **Ethereum** and **Solana** signatures, more are following.

Partly solves: #9 