### PR TITLE
Fix: ETH verify_signature fails on checksummed addresses

### DIFF
--- a/src/aleph/sdk/chains/ethereum.py
+++ b/src/aleph/sdk/chains/ethereum.py
@@ -54,7 +54,7 @@ def verify_signature(
     Verifies a signature.
     Args:
         signature: The signature to verify. Can be a hex encoded string or bytes.
-        public_key: The sender's public key to use for verification. Can be a checksummed, hex encoded string or bytes.
+        public_key: The sender's public key to use for verification. Can be a checksum, hex encoded string or bytes.
         message: The message to verify. Can be an utf-8 string or bytes.
     Raises:
         BadSignatureError: If the signature is invalid.
@@ -75,7 +75,7 @@ def verify_signature(
     message_hash = encode_defunct(text=message)
     try:
         address = Account.recover_message(message_hash, signature=signature)
-        if address != public_key:
+        if address.casefold() != public_key.casefold():
             raise BadSignatureError
     except (EthBadSignatureError, BadSignatureError) as e:
         raise BadSignatureError from e

--- a/tests/unit/test_chain_solana.py
+++ b/tests/unit/test_chain_solana.py
@@ -60,6 +60,10 @@ async def test_SOLAccount(solana_account):
     assert verif == verification_buffer
     assert message["sender"] == signature["publicKey"]
 
+    pubkey = solana_account.get_public_key()
+    assert type(pubkey) == str
+    assert len(pubkey) == 64
+
 
 @pytest.mark.asyncio
 async def test_decrypt_curve25516(solana_account):
@@ -89,6 +93,13 @@ async def test_verify_signature(solana_account):
     assert type(raw_signature) == str
 
     verify_signature(raw_signature, message["sender"], get_verification_buffer(message))
+
+    # as bytes
+    verify_signature(
+        base58.b58decode(raw_signature),
+        base58.b58decode(message["sender"]),
+        get_verification_buffer(message).decode("utf-8"),
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Problem: As Ethereum addresses may contain checksum information in capitalizing their letters, comparing the input address and the resulting public_key of the signature verification process resulted in false negatives.

Solution: Casefold both the address and public key before comparing them. Added further tests to both ETH and SOL accounts to increase coverage and test for other unforeseen errors.