### PR TITLE
Problem: Signatures generated with Python 3.11 are invalid

### DIFF
--- a/src/aleph/sdk/chains/common.py
+++ b/src/aleph/sdk/chains/common.py
@@ -7,6 +7,7 @@ from coincurve.keys import PrivateKey
 from ecies import decrypt, encrypt
 
 from aleph.sdk.conf import settings
+from aleph.sdk.utils import enum_as_str
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +23,16 @@ def get_verification_buffer(message: Dict) -> bytes:
     Returns:
         bytes: Verification buffer
     """
-    return "{chain}\n{sender}\n{type}\n{item_hash}".format(**message).encode("utf-8")
+
+    # Convert Enum values to strings
+    return "\n".join(
+        (
+            enum_as_str(message["chain"]),
+            message["sender"],
+            enum_as_str(message["type"]),
+            message["item_hash"],
+        )
+    ).encode()
 
 
 def get_public_key(private_key):

--- a/src/aleph/sdk/utils.py
+++ b/src/aleph/sdk/utils.py
@@ -1,9 +1,10 @@
 import errno
 import logging
 import os
+from enum import Enum
 from pathlib import Path
 from shutil import make_archive
-from typing import Tuple, Type
+from typing import Tuple, Type, Union
 from zipfile import BadZipFile, ZipFile
 
 from aleph_message.models import MessageType
@@ -76,3 +77,18 @@ def check_unix_socket_valid(unix_socket_path: str) -> bool:
             unix_socket_path,
         )
     return True
+
+
+def enum_as_str(obj: Union[str, Enum]) -> str:
+    """Returns the value of an Enum, or the string itself when passing a string.
+
+    Python 3.11 adds a new formatting of string enums.
+    `str(MyEnum.value)` becomes `MyEnum.value` instead of `value`.
+    """
+    if not isinstance(obj, str):
+        raise TypeError(f"Unsupported enum type: {type(obj)}")
+
+    if isinstance(obj, Enum):
+        return obj.value
+
+    return obj

--- a/tests/unit/test_chains.py
+++ b/tests/unit/test_chains.py
@@ -1,0 +1,18 @@
+from aleph_message.models import Chain, ItemType
+
+from aleph.sdk.chains.common import get_verification_buffer
+
+
+def test_get_verification_buffer():
+    message = {
+        "chain": Chain.ETH,
+        "sender": "0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9",
+        "type": ItemType.inline,
+        "item_hash": "bd79839bf96e595a06da5ac0b6ba51dea6f7e2591bb913deccded04d831d29f4",
+    }
+    assert get_verification_buffer(message) == (
+        b"ETH\n"
+        b"0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9\n"
+        b"inline\n"
+        b"bd79839bf96e595a06da5ac0b6ba51dea6f7e2591bb913deccded04d831d29f4"
+    )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,13 +1,15 @@
 from aleph_message.models import (
     AggregateMessage,
+    Chain,
     ForgetMessage,
+    ItemType,
     MessageType,
     PostMessage,
     ProgramMessage,
     StoreMessage,
 )
 
-from aleph.sdk.utils import get_message_type_value
+from aleph.sdk.utils import enum_as_str, get_message_type_value
 
 
 def test_get_message_type_value():
@@ -16,3 +18,11 @@ def test_get_message_type_value():
     assert get_message_type_value(StoreMessage) == MessageType.store
     assert get_message_type_value(ProgramMessage) == MessageType.program
     assert get_message_type_value(ForgetMessage) == MessageType.forget
+
+
+def test_enum_as_str():
+    assert enum_as_str("simple string") == "simple string"
+    assert enum_as_str(Chain("ETH")) == "ETH"
+    assert enum_as_str(Chain.ETH) == "ETH"
+    assert enum_as_str(ItemType("inline")) == "inline"
+    assert enum_as_str(ItemType.inline) == "inline"


### PR DESCRIPTION
The signature buffer is affected by the new formatting of string
enums.

Solution: use the value of the message type enum.

Co-authored-by: Olivier Desenfans <desenfans.olivier@gmail.com>
