### PR TITLE
Fix: SDK error when retrieving fallback private key, but the symlink was dead.

### DIFF
--- a/src/aleph/sdk/chains/common.py
+++ b/src/aleph/sdk/chains/common.py
@@ -120,7 +120,11 @@ def get_fallback_private_key(path: Optional[Path] = None) -> bytes:
         path.write_bytes(private_key)
 
         default_key_path = path.parent / "default.key"
+
+        # We check if the symlink exist but dead to remove it
+        if default_key_path.is_symlink() and not default_key_path.resolve().exists():
+            default_key_path.unlink()
+
+        # We create the symlink if symlink not exist
         if not default_key_path.exists():
-            # Create a symlink to use this key by default
             default_key_path.symlink_to(path)
-    return private_key

--- a/src/aleph/sdk/chains/common.py
+++ b/src/aleph/sdk/chains/common.py
@@ -127,10 +127,9 @@ def get_fallback_private_key(path: Optional[Path] = None) -> bytes:
         # If the symlink exists but does not point to a file, delete it.
         if default_key_path.is_symlink() and not default_key_path.resolve().exists():
             default_key_path.unlink()
-            logger.debug("Removed dead symlink")
+            logger.warning("The symlink to the private key is broken")
 
         # Create a symlink to use this key by default
         if not default_key_path.exists():
             default_key_path.symlink_to(path)
-            logger.debug("Create symlink")
     return private_key

--- a/src/aleph/sdk/chains/common.py
+++ b/src/aleph/sdk/chains/common.py
@@ -128,3 +128,4 @@ def get_fallback_private_key(path: Optional[Path] = None) -> bytes:
         # We create the symlink if symlink not exist
         if not default_key_path.exists():
             default_key_path.symlink_to(path)
+    return private_key

--- a/src/aleph/sdk/chains/common.py
+++ b/src/aleph/sdk/chains/common.py
@@ -121,7 +121,7 @@ def get_fallback_private_key(path: Optional[Path] = None) -> bytes:
 
         default_key_path = path.parent / "default.key"
 
-        # We check if the symlink exist but dead to remove it
+        # If the symlink exists but does not point to a file, delete it.
         if default_key_path.is_symlink() and not default_key_path.resolve().exists():
             default_key_path.unlink()
 

--- a/src/aleph/sdk/chains/common.py
+++ b/src/aleph/sdk/chains/common.py
@@ -7,6 +7,9 @@ from ecies import decrypt, encrypt
 
 from aleph.sdk.conf import settings
 
+import logging
+
+logger = logging.getLogger(__name__)
 
 def get_verification_buffer(message: Dict) -> bytes:
     """
@@ -124,8 +127,10 @@ def get_fallback_private_key(path: Optional[Path] = None) -> bytes:
         # If the symlink exists but does not point to a file, delete it.
         if default_key_path.is_symlink() and not default_key_path.resolve().exists():
             default_key_path.unlink()
+            logger.debug("Removed dead symlink")
 
         # Create a symlink to use this key by default
         if not default_key_path.exists():
             default_key_path.symlink_to(path)
+            logger.debug("Create symlink")
     return private_key

--- a/src/aleph/sdk/chains/common.py
+++ b/src/aleph/sdk/chains/common.py
@@ -125,7 +125,7 @@ def get_fallback_private_key(path: Optional[Path] = None) -> bytes:
         if default_key_path.is_symlink() and not default_key_path.resolve().exists():
             default_key_path.unlink()
 
-        # We create the symlink if symlink not exist
+        # Create a symlink to use this key by default
         if not default_key_path.exists():
             default_key_path.symlink_to(path)
     return private_key


### PR DESCRIPTION
Problem: The symlink can exist, but it can be dead. For example, unit tests may remove the file but not the symlink.

Solution: We add a check to determine if it is a symlink and if it is dead. In this case, we unlink it.
