### PR TITLE
Feature: download on ipfs client

### DIFF
--- a/src/aleph/sdk/client.py
+++ b/src/aleph/sdk/client.py
@@ -650,7 +650,7 @@ class AlephClient:
         :param chunk_size: Size of chunk we download.
         """
         async with aiohttp.ClientSession() as session:
-            async with session.get(f"https://ipfs.io/ipfs/{file_hash}") as response:
+            async with session.get(f"https://ipfs.aleph.im/ipfs/{file_hash}") as response:
                 response.raise_for_status()
                 while True:
                     chunk = await response.content.read(chunk_size)

--- a/src/aleph/sdk/client.py
+++ b/src/aleph/sdk/client.py
@@ -23,6 +23,8 @@ from typing import (
     TypeVar,
     Union,
 )
+from io import BytesIO
+from typing import BinaryIO
 
 import aiohttp
 from aleph_message.models import (
@@ -225,8 +227,11 @@ class UserSessionSync:
             end_date=end_date,
         )
 
-    def download_file(self, file_hash: str) -> bytes:
-        return self._wrap(self.async_session.download_file, file_hash=file_hash)
+    def download_file(self, file_hash: str, chunk_size :int = 16 * 1024) -> bytes:
+        return self._wrap(self.async_session.download_file, file_hash=file_hash, chunk_size=chunk_size)
+
+    def download_file_ipfs(self, file_hash: str, chunk_size : int = 16 * 1024) -> bytes:
+        return self._wrap(self.async_session.download_file_ipfs, file_hash=file_hash, chunk_size=chunk_size)
 
     def watch_messages(
         self,
@@ -608,9 +613,55 @@ class AlephClient:
             resp.raise_for_status()
             return await resp.json()
 
+    async def download_file_to_buffer(
+            self,
+            file_hash: str,
+            output_buffer: BinaryIO,
+            chunk_size: int,
+    ) -> None:
+        """
+        Download a file from the storage engine and write it to the specified output buffer.
+        :param self: The current instance of the class.
+        :param file_hash: The hash of the file to retrieve.
+        :param output_buffer: The binary output buffer to write the file data to.
+        :param chunk_size: Size of the chunk to download.
+        """
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"https://api1.aleph.im/api/v0/storage/raw/{file_hash}") as response:
+                response.raise_for_status()
+
+                while True:
+                    chunk = await response.content.read(chunk_size)
+                    if not chunk:
+                        break
+                    output_buffer.write(chunk)
+
+    async def download_file_ipfs_to_buffer(
+            self,
+            file_hash: str,
+            output_buffer: BinaryIO,
+            chunk_size : int,
+    ) -> None:
+        """
+        Download a file from the storage engine and write it to the specified output buffer.
+
+        :param file_hash: The hash of the file to retrieve.
+        :param output_buffer: The binary output buffer to write the file data to.
+        :param chunk_size: Size of chunk we download.
+        """
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"https://ipfs.io/ipfs/{file_hash}") as response:
+                response.raise_for_status()
+                while True:
+                    chunk = await response.content.read(chunk_size)
+                    if not chunk:
+                        break
+                    output_buffer.write(chunk)
+
     async def download_file(
         self,
         file_hash: str,
+        chunk_size: int = 16 * 1024,
     ) -> bytes:
         """
         Get a file from the storage engine as raw bytes.
@@ -618,12 +669,29 @@ class AlephClient:
         Warning: Downloading large files can be slow and memory intensive.
 
         :param file_hash: The hash of the file to retrieve.
+        :param chunk_size: The size of each chunk to read from the response.
         """
-        async with self.http_session.get(
-            f"/api/v0/storage/raw/{file_hash}"
-        ) as response:
-            response.raise_for_status()
-            return await response.read()
+        buffer = BytesIO()
+        await self.download_file_to_buffer(file_hash, output_buffer=buffer, chunk_size=chunk_size)
+        return buffer.getvalue()
+
+
+    async def download_file_ipfs(
+        self,
+        file_hash: str,
+        chunk_size: int = 16 * 1024,
+    ) -> bytes:
+        """
+        Get a file from the ipfs storage engine as raw bytes.
+
+        Warning: Downloading large files can be slow.
+
+        :param file_hash: The hash of the file to retrieve.
+        :param chunk_size: The size of each chunk to read from the response.
+        """
+        buffer = BytesIO()
+        await self.download_file_ipfs_to_buffer(file_hash, output_buffer=buffer, chunk_size=chunk_size)
+        return buffer.getvalue()
 
     async def get_messages(
         self,

--- a/src/aleph/sdk/client.py
+++ b/src/aleph/sdk/client.py
@@ -627,7 +627,7 @@ class AlephClient:
         :param chunk_size: Size of the chunk to download.
         """
         async with aiohttp.ClientSession() as session:
-            async with session.get(f"https://api1.aleph.im/api/v0/storage/raw/{file_hash}") as response:
+            async with session.get(f"https://official.aleph.im/api/v0/storage/raw/{file_hash}") as response:
                 response.raise_for_status()
 
                 while True:

--- a/src/aleph/sdk/client.py
+++ b/src/aleph/sdk/client.py
@@ -227,11 +227,17 @@ class UserSessionSync:
             end_date=end_date,
         )
 
-    def download_file(self, file_hash: str, chunk_size :int = 16 * 1024) -> bytes:
-        return self._wrap(self.async_session.download_file, file_hash=file_hash, chunk_size=chunk_size)
+    def download_file(self, file_hash: str, chunk_size: int = 16 * 1024) -> bytes:
+        return self._wrap(
+            self.async_session.download_file, file_hash=file_hash, chunk_size=chunk_size
+        )
 
-    def download_file_ipfs(self, file_hash: str, chunk_size : int = 16 * 1024) -> bytes:
-        return self._wrap(self.async_session.download_file_ipfs, file_hash=file_hash, chunk_size=chunk_size)
+    def download_file_ipfs(self, file_hash: str, chunk_size: int = 16 * 1024) -> bytes:
+        return self._wrap(
+            self.async_session.download_file_ipfs,
+            file_hash=file_hash,
+            chunk_size=chunk_size,
+        )
 
     def watch_messages(
         self,
@@ -614,20 +620,21 @@ class AlephClient:
             return await resp.json()
 
     async def download_file_to_buffer(
-            self,
-            file_hash: str,
-            output_buffer: BinaryIO,
-            chunk_size: int,
+        self,
+        file_hash: str,
+        output_buffer: BinaryIO,
+        chunk_size: int,
     ) -> None:
         """
         Download a file from the storage engine and write it to the specified output buffer.
-        :param self: The current instance of the class.
         :param file_hash: The hash of the file to retrieve.
         :param output_buffer: The binary output buffer to write the file data to.
         :param chunk_size: Size of the chunk to download.
         """
         async with aiohttp.ClientSession() as session:
-            async with session.get(f"https://official.aleph.im/api/v0/storage/raw/{file_hash}") as response:
+            async with self.http_session.get(
+                f"/api/v0/storage/raw/{file_hash}"
+            ) as response:
                 response.raise_for_status()
 
                 while True:
@@ -637,10 +644,10 @@ class AlephClient:
                     output_buffer.write(chunk)
 
     async def download_file_ipfs_to_buffer(
-            self,
-            file_hash: str,
-            output_buffer: BinaryIO,
-            chunk_size : int,
+        self,
+        file_hash: str,
+        output_buffer: BinaryIO,
+        chunk_size: int,
     ) -> None:
         """
         Download a file from the storage engine and write it to the specified output buffer.
@@ -650,7 +657,9 @@ class AlephClient:
         :param chunk_size: Size of chunk we download.
         """
         async with aiohttp.ClientSession() as session:
-            async with session.get(f"https://ipfs.aleph.im/ipfs/{file_hash}") as response:
+            async with session.get(
+                f"https://ipfs.aleph.im/ipfs/{file_hash}"
+            ) as response:
                 response.raise_for_status()
                 while True:
                     chunk = await response.content.read(chunk_size)
@@ -672,9 +681,10 @@ class AlephClient:
         :param chunk_size: The size of each chunk to read from the response.
         """
         buffer = BytesIO()
-        await self.download_file_to_buffer(file_hash, output_buffer=buffer, chunk_size=chunk_size)
+        await self.download_file_to_buffer(
+            file_hash, output_buffer=buffer, chunk_size=chunk_size
+        )
         return buffer.getvalue()
-
 
     async def download_file_ipfs(
         self,
@@ -690,7 +700,9 @@ class AlephClient:
         :param chunk_size: The size of each chunk to read from the response.
         """
         buffer = BytesIO()
-        await self.download_file_ipfs_to_buffer(file_hash, output_buffer=buffer, chunk_size=chunk_size)
+        await self.download_file_ipfs_to_buffer(
+            file_hash, output_buffer=buffer, chunk_size=chunk_size
+        )
         return buffer.getvalue()
 
     async def get_messages(

--- a/src/aleph/sdk/client.py
+++ b/src/aleph/sdk/client.py
@@ -70,10 +70,6 @@ except ImportError:
 T = TypeVar("T")
 
 
-class ModelWithItemHash(BaseModel):
-    hash: ItemHash
-
-
 def async_wrapper(f):
     """
     Copies the docstring of wrapped functions.

--- a/src/aleph/sdk/exceptions.py
+++ b/src/aleph/sdk/exceptions.py
@@ -42,3 +42,11 @@ class BadSignatureError(Exception):
     """
 
     pass
+
+
+class FileTooLarge(Exception):
+    """
+    A file is too large
+    """
+
+    pass

--- a/src/aleph/sdk/utils.py
+++ b/src/aleph/sdk/utils.py
@@ -12,6 +12,13 @@ from aleph_message.models.program import Encoding
 from aleph.sdk.conf import settings
 from aleph.sdk.types import GenericMessage
 
+from typing import (
+    Tuple,
+    Type,
+    TypeVar,
+    Protocol,
+)
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -76,3 +83,27 @@ def check_unix_socket_valid(unix_socket_path: str) -> bool:
             unix_socket_path,
         )
     return True
+
+
+C = TypeVar("C", str, bytes, covariant=True)
+U = TypeVar("U", str, bytes, contravariant=True)
+
+
+class AsyncReadable(Protocol[C]):
+    async def read(self, n: int = -1) -> C:
+        ...
+
+
+class Writable(Protocol[U]):
+    def write(self, buffer: U) -> int:
+        ...
+
+
+async def copy_async_readable_to_buffer(
+    readable: AsyncReadable[C], buffer: Writable[C], chunk_size: int
+):
+    while True:
+        chunk = await readable.read(chunk_size)
+        if not chunk:
+            break
+        buffer.write(chunk)

--- a/src/aleph/sdk/utils.py
+++ b/src/aleph/sdk/utils.py
@@ -54,7 +54,7 @@ def create_archive(path: Path) -> Tuple[Path, Encoding]:
             return archive_path, Encoding.zip
     elif os.path.isfile(path):
         if path.suffix == ".squashfs" or (
-            magic and magic.from_file(path).startswith("Squashfs filesystem")
+                magic and magic.from_file(path).startswith("Squashfs filesystem")
         ):
             return path, Encoding.squashfs
         else:
@@ -85,6 +85,7 @@ def check_unix_socket_valid(unix_socket_path: str) -> bool:
         )
     return True
 
+
 T = TypeVar("T", str, bytes, covariant=True)
 U = TypeVar("U", str, bytes, contravariant=True)
 
@@ -100,7 +101,7 @@ class Writable(Protocol[U]):
 
 
 async def copy_async_readable_to_buffer(
-    readable: AsyncReadable[T], buffer: Writable[T], chunk_size: int
+        readable: AsyncReadable[T], buffer: Writable[T], chunk_size: int
 ):
     while True:
         chunk = await readable.read(chunk_size)

--- a/src/aleph/sdk/utils.py
+++ b/src/aleph/sdk/utils.py
@@ -85,12 +85,12 @@ def check_unix_socket_valid(unix_socket_path: str) -> bool:
     return True
 
 
-C = TypeVar("C", str, bytes, covariant=True)
+T = TypeVar("T", str, bytes, covariant=True)
 U = TypeVar("U", str, bytes, contravariant=True)
 
 
-class AsyncReadable(Protocol[C]):
-    async def read(self, n: int = -1) -> C:
+class AsyncReadable(Protocol[T]):
+    async def read(self, n: int = -1) -> T:
         ...
 
 
@@ -100,7 +100,7 @@ class Writable(Protocol[U]):
 
 
 async def copy_async_readable_to_buffer(
-    readable: AsyncReadable[C], buffer: Writable[C], chunk_size: int
+    readable: AsyncReadable[T], buffer: Writable[T], chunk_size: int
 ):
     while True:
         chunk = await readable.read(chunk_size)

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -1,0 +1,32 @@
+import pytest
+from aleph.sdk import AlephClient
+from aleph.sdk.conf import settings as sdk_settings
+
+
+@pytest.mark.asyncio
+def test_download():
+    with AlephClient(
+        api_server=sdk_settings.API_HOST
+    ) as client:
+        file_size: int = 0
+        try:
+            file_content = client.download_file("QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH")  # File is 5B
+            file_size = len(file_content)
+        except Exception as e:
+            pass
+        assert file_size == 5
+
+
+@pytest.mark.asyncio
+def test_download_ipfs():
+    with AlephClient(
+            api_server=sdk_settings.API_HOST
+    ) as client:
+        file_size: int = 0
+        try:
+            file_content = client.download_file_ipfs(
+                "Qmdy5LaAL4eghxE7JD6Ah5o4PJGarjAV9st8az2k52i1vq")  ## 5817703 B FILE
+            file_size = len(file_content)
+        except Exception as e:
+            pass
+        assert file_size == 5817703

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -3,30 +3,31 @@ from aleph.sdk import AlephClient
 from aleph.sdk.conf import settings as sdk_settings
 
 
+@pytest.mark.parametrize(
+    "file_hash,expected_size",
+    [
+        ("QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH", 5),
+        ("Qmdy5LaAL4eghxE7JD6Ah5o4PJGarjAV9st8az2k52i1vq", 5817703),
+    ],
+)
 @pytest.mark.asyncio
-def test_download():
-    with AlephClient(
-        api_server=sdk_settings.API_HOST
-    ) as client:
-        file_size: int = 0
-        try:
-            file_content = client.download_file("QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH")  # File is 5B
-            file_size = len(file_content)
-        except Exception as e:
-            pass
-        assert file_size == 5
+async def test_download(file_hash: str, expected_size: int):
+    async with AlephClient(api_server=sdk_settings.API_HOST) as client:
+        file_content = await client.download_file(file_hash)  # File is 5B
+        file_size = len(file_content)
+        assert file_size == expected_size
 
 
+@pytest.mark.parametrize(
+    "file_hash,expected_size",
+    [
+        ("QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH", 5),
+        ("Qmdy5LaAL4eghxE7JD6Ah5o4PJGarjAV9st8az2k52i1vq", 5817703),
+    ],
+)
 @pytest.mark.asyncio
-def test_download_ipfs():
-    with AlephClient(
-            api_server=sdk_settings.API_HOST
-    ) as client:
-        file_size: int = 0
-        try:
-            file_content = client.download_file_ipfs(
-                "Qmdy5LaAL4eghxE7JD6Ah5o4PJGarjAV9st8az2k52i1vq")  ## 5817703 B FILE
-            file_size = len(file_content)
-        except Exception as e:
-            pass
-        assert file_size == 5817703
+async def test_download_ipfs(file_hash: str, expected_size: int):
+    async with AlephClient(api_server=sdk_settings.API_HOST) as client:
+        file_content = await client.download_file_ipfs(file_hash)  ## 5817703 B FILE
+        file_size = len(file_content)
+        assert file_size == expected_size

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -17,17 +17,3 @@ async def test_download(file_hash: str, expected_size: int):
         file_size = len(file_content)
         assert file_size == expected_size
 
-
-@pytest.mark.parametrize(
-    "file_hash,expected_size",
-    [
-        ("QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH", 5),
-        ("Qmdy5LaAL4eghxE7JD6Ah5o4PJGarjAV9st8az2k52i1vq", 5817703),
-    ],
-)
-@pytest.mark.asyncio
-async def test_download_ipfs(file_hash: str, expected_size: int):
-    async with AlephClient(api_server=sdk_settings.API_HOST) as client:
-        file_content = await client.download_file_ipfs(file_hash)  ## 5817703 B FILE
-        file_size = len(file_content)
-        assert file_size == expected_size

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -17,3 +17,17 @@ async def test_download(file_hash: str, expected_size: int):
         file_size = len(file_content)
         assert file_size == expected_size
 
+
+@pytest.mark.parametrize(
+    "file_hash,expected_size",
+    [
+        ("QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH", 5),
+        ("Qmdy5LaAL4eghxE7JD6Ah5o4PJGarjAV9st8az2k52i1vq", 5817703),
+    ],
+)
+@pytest.mark.asyncio
+async def test_download_ipfs(file_hash: str, expected_size: int):
+    async with AlephClient(api_server=sdk_settings.API_HOST) as client:
+        file_content = await client.download_file_ipfs(file_hash)  ## 5817703 B FILE
+        file_size = len(file_content)
+        assert file_size == expected_size


### PR DESCRIPTION

Solutions:
   - Add a function called download_file_ipfs that downloads from ipfs.io/ipfs/.
   - Refactor the current download process to include:
      - Chunk size and storage into a buffer (BytesIO). (memory friendly)
   - Add a test for the download functionality.