### PR TITLE
Fix: CI was broken because of aiomqtt update

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ exclude =
 # PDF = ReportLab; RXP
 # Add here test requirements (semicolon/line-separated)
 testing =
-    aiomqtt
+    aiomqtt<=0.1.3
     psutil
     pytest
     pytest-cov
@@ -80,7 +80,7 @@ testing =
     isort
     flake8
 mqtt =
-    aiomqtt
+    aiomqtt<=0.1.3
     certifi
     Click
 nuls2 =

--- a/src/aleph/sdk/chains/common.py
+++ b/src/aleph/sdk/chains/common.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Dict, Optional
@@ -7,9 +8,8 @@ from ecies import decrypt, encrypt
 
 from aleph.sdk.conf import settings
 
-import logging
-
 logger = logging.getLogger(__name__)
+
 
 def get_verification_buffer(message: Dict) -> bytes:
     """


### PR DESCRIPTION
Problem: aiomqtt has been taken over by a completely different team and the new version (1.0.0) is completely incompatible with our current example.

Solution: use the latest version of the old project.