### PR TITLE
Fix: package could not be published to Pypi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,8 +84,7 @@ mqtt =
     certifi
     Click
 nuls2 =
-    # use the branch with support for Python 3.11
-    nuls2-python@git+https://github.com/odesenfans/nuls2-python.git@fda2ba4a5f9397f4f84cfee738942c4a15f88840
+    aleph-nuls2
 ethereum =
     eth_account>=0.4.0
     # Required to fix a dependency issue with parsimonious and Python3.11


### PR DESCRIPTION
Problem: publishing a package with Github dependencies is not allowed on Pypi. We use a Github dependency for NULS2 support.

Solution: use the new aleph-nuls2 package directly.