### PR TITLE
Fix: support 405 from POST /messages in broadcast fallback

### DIFF
--- a/src/aleph/sdk/client.py
+++ b/src/aleph/sdk/client.py
@@ -1138,7 +1138,7 @@ class AuthenticatedAlephClient(AlephClient):
             json={"sync": sync, "message": message_dict},
         ) as response:
             # The endpoint may be unavailable on this node, try the deprecated version.
-            if response.status == 404:
+            if response.status in (404, 405):
                 logger.warning(
                     "POST /messages/ not found. Defaulting to legacy endpoint..."
                 )


### PR DESCRIPTION
Problem: a user reports that publishing a message falls because of a 405 error returned from `POST /messages`. The fallback only takes 404 into account, but a 405 is actually more likely because `GET /messages` exists.

Solution: accept both 404 and 405 as a sign that the node does not support `POST /messages`.