### PR TITLE
Fix: allow user to specify datetime and UUID objects in post content

### DIFF
--- a/src/aleph/sdk/client.py
+++ b/src/aleph/sdk/client.py
@@ -47,6 +47,7 @@ from aleph_message.models import (
 from aleph_message.models.execution.base import Encoding
 from aleph_message.status import MessageStatus
 from pydantic import ValidationError
+from pydantic.json import pydantic_encoder
 
 from aleph.sdk.types import Account, GenericMessage, StorageEnum
 from aleph.sdk.utils import Writable, copy_async_readable_to_buffer
@@ -1475,7 +1476,10 @@ class AuthenticatedAlephClient(AlephClient):
             "channel": channel,
         }
 
-        item_content: str = json.dumps(content, separators=(",", ":"))
+        # Use the Pydantic encoder to serialize types like UUID, datetimes, etc.
+        item_content: str = json.dumps(
+            content, separators=(",", ":"), default=pydantic_encoder
+        )
 
         if allow_inlining and (len(item_content) < settings.MAX_INLINE_SIZE):
             message_dict["item_content"] = item_content


### PR DESCRIPTION
Problem: using `create_post()` with an object containing datetime, UUIDs and other types not serializable by the Python `json` module fails.

Solution: as we already use Pydantic all over the place, use the Pydantic encoder as default for all the types not serializable by the `json` module.