### PR TITLE
Fix: Default runtime was obsolete

### DIFF
--- a/src/aleph/sdk/conf.py
+++ b/src/aleph/sdk/conf.py
@@ -29,9 +29,7 @@ class Settings(BaseSettings):
     REMOTE_CRYPTO_UNIX_SOCKET: Optional[str] = None
     ADDRESS_TO_USE: Optional[str] = None
 
-    DEFAULT_RUNTIME_ID: str = (
-        "bd79839bf96e595a06da5ac0b6ba51dea6f7e2591bb913deccded04d831d29f4"
-    )
+    DEFAULT_RUNTIME_ID: str = "f873715dc2feec3833074bd4b8745363a0e0093746b987b4c8191268883b2463"  # Debian 12 official runtime
     DEFAULT_VM_MEMORY: int = 256
     DEFAULT_VM_VCPUS: int = 1
     DEFAULT_VM_TIMEOUT: float = 30.0


### PR DESCRIPTION
We released a new runtime based on Debian 12.

This changes the default configuration to use the new runtime.
