### PR TITLE
Fix: add ledgereth to "testing" install target

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,7 @@ testing =
     flake8
     substrate-interface
     py-sr25519-bindings
+    ledgereth==0.9.0
 mqtt =
     aiomqtt<=0.1.3
     certifi


### PR DESCRIPTION
Problem: `pip install .[testing]` is not enough to run all tests successfully.

Solution: add missing packages to the "testing" install target.