### PR TITLE
PR Difficulty Rating Workflow

### DIFF
--- a/.github/workflows/pr-rating.yml
+++ b/.github/workflows/pr-rating.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: PR Difficulty Rating
-        uses: rate-my-pr/rate@v1.0.10
+        uses: rate-my-pr/rate@v1.0.11
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LLAMA_URL: ${{ secrets.LLAMA_URL }}

--- a/.github/workflows/pr-rating.yml
+++ b/.github/workflows/pr-rating.yml
@@ -1,0 +1,16 @@
+name: Test PR Difficulty Rating Action
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  difficulty-rating:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: PR Difficulty Rating
+        uses: MHHukiewitz/pr-rating-action@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PR_RATING_TOKEN }}
+          LLAMA_URL: ${{ secrets.LLAMA_URL }}

--- a/.github/workflows/pr-rating.yml
+++ b/.github/workflows/pr-rating.yml
@@ -1,5 +1,8 @@
 name: Test PR Difficulty Rating Action
 
+permissions:
+  pull-requests: write
+
 on:
   pull_request:
     types: [opened, reopened, ready_for_review]
@@ -12,5 +15,5 @@ jobs:
       - name: PR Difficulty Rating
         uses: MHHukiewitz/pr-rating-action@main
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PR_RATING_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LLAMA_URL: ${{ secrets.LLAMA_URL }}

--- a/.github/workflows/pr-rating.yml
+++ b/.github/workflows/pr-rating.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: PR Difficulty Rating
-        uses: rate-my-pr/rate@v1.0.7
+        uses: rate-my-pr/rate@v1.0.8
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LLAMA_URL: ${{ secrets.LLAMA_URL }}

--- a/.github/workflows/pr-rating.yml
+++ b/.github/workflows/pr-rating.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: PR Difficulty Rating
-        uses: rate-my-pr/rate@v1.0.8
+        uses: rate-my-pr/rate@v1.0.10
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LLAMA_URL: ${{ secrets.LLAMA_URL }}

--- a/.github/workflows/pr-rating.yml
+++ b/.github/workflows/pr-rating.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - name: PR Difficulty Rating
-        uses: MHHukiewitz/pr-rating-action@main
+        uses: rate-my-pr/rate@v1.0.7
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LLAMA_URL: ${{ secrets.LLAMA_URL }}


### PR DESCRIPTION
Add PR Difficulty Rating workflow to test and rate the difficulty of pull requests. See https://github.com/rate-my-pr/rate

> Provides a difficulty rating for PRs based on content diffs. Ratings are
> 
> BLUE: Simple, low risk changes, such as documentation, comments, etc.
> RED: Complex, high risk changes, such as refactors, new features, etc.
> BLACK: Very complex, very high risk changes, such as large refactors, modifications to core functionality, etc.