### PR TITLE
Add extended JSON encoder for datetime objects in message encoding

### DIFF
--- a/src/aleph/sdk/client/authenticated_http.py
+++ b/src/aleph/sdk/client/authenticated_http.py
@@ -1,3 +1,4 @@
+import datetime
 import hashlib
 import json
 import logging
@@ -48,6 +49,16 @@ try:
 except ImportError:
     logger.info("Could not import library 'magic', MIME type detection disabled")
     magic = None  # type:ignore
+
+
+def extended_json_encoder(obj: Any) -> str:
+    if (
+        isinstance(obj, datetime.datetime)
+        or isinstance(obj, datetime.date)
+        or isinstance(obj, datetime.time)
+    ):
+        return obj.isoformat()  # or any other format you prefer
+    return pydantic_encoder(obj)
 
 
 class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
@@ -604,7 +615,7 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
 
         # Use the Pydantic encoder to serialize types like UUID, datetimes, etc.
         item_content: str = json.dumps(
-            content, separators=(",", ":"), default=pydantic_encoder
+            content, separators=(",", ":"), default=extended_json_encoder
         )
 
         if allow_inlining and (len(item_content) < settings.MAX_INLINE_SIZE):

--- a/tests/unit/test_asynchronous.py
+++ b/tests/unit/test_asynchronous.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest.mock import AsyncMock
 
 import pytest as pytest
@@ -5,10 +6,12 @@ from aleph_message.models import (
     AggregateMessage,
     ForgetMessage,
     InstanceMessage,
+    MessageType,
     PostMessage,
     ProgramMessage,
     StoreMessage,
 )
+from aleph_message.models.execution.environment import MachineResources
 from aleph_message.status import MessageStatus
 
 from aleph.sdk.types import StorageEnum
@@ -121,3 +124,63 @@ async def test_forget(mock_session_with_post_success):
 
     assert mock_session_with_post_success.http_session.post.called_once
     assert isinstance(forget_message, ForgetMessage)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message_type, content",
+    [
+        (
+            MessageType.aggregate,
+            {
+                "content": {"Hello": datetime.datetime.now()},
+                "key": "test",
+                "address": "0x1",
+                "time": 1.0,
+            },
+        ),
+        (
+            MessageType.aggregate,
+            {
+                "content": {"Hello": datetime.date.today()},
+                "key": "test",
+                "address": "0x1",
+                "time": 1.0,
+            },
+        ),
+        (
+            MessageType.aggregate,
+            {
+                "content": {"Hello": datetime.time()},
+                "key": "test",
+                "address": "0x1",
+                "time": 1.0,
+            },
+        ),
+        (
+            MessageType.aggregate,
+            {
+                "content": {
+                    "Hello": MachineResources(
+                        vcpus=1,
+                        memory=1024,
+                        seconds=1,
+                    )
+                },
+                "key": "test",
+                "address": "0x1",
+                "time": 1.0,
+            },
+        ),
+    ],
+)
+async def test_prepare_aleph_message(
+    mock_session_with_post_success, message_type, content
+):
+    # Call the function under test
+    async with mock_session_with_post_success as session:
+        await session._prepare_aleph_message(
+            message_type=message_type,
+            content=content,
+            channel="TEST",
+        )


### PR DESCRIPTION
Supersedes https://github.com/aleph-im/aleph-client/pull/131