### PR TITLE
Refactor: Add `InsufficientFundsError` in `create_instance`

### DIFF
--- a/.github/workflows/pr-rating.yml
+++ b/.github/workflows/pr-rating.yml
@@ -1,4 +1,4 @@
-name: Test PR Difficulty Rating Action
+name: PR Difficulty Rating Action
 
 permissions:
   pull-requests: write

--- a/src/aleph/sdk/client/abstract.py
+++ b/src/aleph/sdk/client/abstract.py
@@ -428,7 +428,8 @@ class AuthenticatedAlephClient(AlephClient):
         storage_engine: StorageEnum = StorageEnum.storage,
         allow_inlining: bool = True,
         sync: bool = False,
-    ) -> Tuple[AlephMessage, MessageStatus]:
+        raise_on_rejected: bool = True,
+    ) -> Tuple[AlephMessage, MessageStatus, Optional[Dict[str, Any]]]:
         """
         Submit a message to the network. This is a generic method that can be used to submit any type of message.
         Prefer using the more specific methods to submit messages.
@@ -439,6 +440,7 @@ class AuthenticatedAlephClient(AlephClient):
         :param storage_engine: Storage engine to use (Default: "storage")
         :param allow_inlining: Whether to allow inlining the content of the message (Default: True)
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
+        :param raise_on_rejected: Whether to raise an exception if the message is rejected (Default: True)
         """
         pass
 

--- a/src/aleph/sdk/client/authenticated_http.py
+++ b/src/aleph/sdk/client/authenticated_http.py
@@ -574,17 +574,6 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         # get the reason for rejection
         rejected_message = await self.get_message_error(message.item_hash)
         assert rejected_message, "No rejected message found"
-        """
-            "error_code": 5,
-            "details": {
-                "errors": [
-                    {
-                        "account_balance": "0",
-                        "required_balance": "4213.265726725260407192763523"
-                    }
-                ]
-            }
-        """
         error_code = rejected_message["error_code"]
         if error_code == 5:
             # not enough balance

--- a/src/aleph/sdk/client/authenticated_http.py
+++ b/src/aleph/sdk/client/authenticated_http.py
@@ -583,7 +583,7 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
             account_balance = float(error["account_balance"])
             required_balance = float(error["required_balance"])
             raise InsufficientFundsError(
-                f"Account balance {account_balance} is not enough to create instance, required {required_balance}"
+                required_funds=required_balance, available_funds=account_balance
             )
         else:
             raise ValueError(f"Unknown error code {error_code}: {rejected_message}")

--- a/src/aleph/sdk/client/authenticated_http.py
+++ b/src/aleph/sdk/client/authenticated_http.py
@@ -404,6 +404,7 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
             allow_inlining=True,
             sync=sync,
         )
+        return message, status
 
     async def create_program(
         self,

--- a/src/aleph/sdk/client/authenticated_http.py
+++ b/src/aleph/sdk/client/authenticated_http.py
@@ -35,7 +35,7 @@ from aleph_message.models.execution.volume import MachineVolume, ParentVolume
 from aleph_message.status import MessageStatus
 
 from ..conf import settings
-from ..exceptions import BroadcastError, InvalidMessageError, InsufficientFundsError
+from ..exceptions import BroadcastError, InsufficientFundsError, InvalidMessageError
 from ..types import Account, StorageEnum
 from ..utils import extended_json_encoder
 from .abstract import AuthenticatedAlephClient
@@ -691,7 +691,9 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
             allow_inlining=allow_inlining,
             storage_engine=storage_engine,
         )
-        response, message_status = await self._broadcast(message=message, sync=sync, raise_on_rejected=raise_on_rejected)
+        response, message_status = await self._broadcast(
+            message=message, sync=sync, raise_on_rejected=raise_on_rejected
+        )
         return message, message_status, response
 
     async def _storage_push_file_with_message(

--- a/src/aleph/sdk/exceptions.py
+++ b/src/aleph/sdk/exceptions.py
@@ -24,7 +24,9 @@ class BroadcastError(Exception):
     Data could not be broadcast to the aleph.im network.
     """
 
-    pass
+    def __init__(self, errors):
+        self.errors = errors
+        super().__init__(errors)
 
 
 class InvalidMessageError(BroadcastError):
@@ -60,5 +62,11 @@ class DomainConfigurationError(Exception):
 
 class ForgottenMessageError(QueryError):
     """The requested message was forgotten"""
+
+    pass
+
+
+class InsufficientFundsError(Exception):
+    """Raised when the account does not have enough funds to perform an action"""
 
     pass

--- a/src/aleph/sdk/exceptions.py
+++ b/src/aleph/sdk/exceptions.py
@@ -69,4 +69,12 @@ class ForgottenMessageError(QueryError):
 class InsufficientFundsError(Exception):
     """Raised when the account does not have enough funds to perform an action"""
 
-    pass
+    required_funds: float
+    available_funds: float
+
+    def __init__(self, required_funds: float, available_funds: float):
+        self.required_funds = required_funds
+        self.available_funds = available_funds
+        super().__init__(
+            f"Insufficient funds: required {required_funds}, available {available_funds}"
+        )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -223,20 +223,27 @@ def make_mock_get_session(get_return_value: Dict[str, Any]) -> AlephHttpClient:
 
 
 @pytest.fixture
-def mock_session_with_rejected_message(ethereum_account, rejected_message) -> AuthenticatedAlephHttpClient:
+def mock_session_with_rejected_message(
+    ethereum_account, rejected_message
+) -> AuthenticatedAlephHttpClient:
     class MockHttpSession(AsyncMock):
         def get(self, *_args, **_kwargs):
             return make_custom_mock_response(rejected_message)
 
         def post(self, *_args, **_kwargs):
-            return make_custom_mock_response({
-                "message_status": "rejected",
-                "publication_status": {"status": "success", "failed": []},
-            }, status=422)
+            return make_custom_mock_response(
+                {
+                    "message_status": "rejected",
+                    "publication_status": {"status": "success", "failed": []},
+                },
+                status=422,
+            )
 
     http_session = MockHttpSession()
 
-    client = AuthenticatedAlephHttpClient(account=ethereum_account, api_server="http://localhost")
+    client = AuthenticatedAlephHttpClient(
+        account=ethereum_account, api_server="http://localhost"
+    )
     client.http_session = http_session
 
     return client

--- a/tests/unit/rejected_message.json
+++ b/tests/unit/rejected_message.json
@@ -1,0 +1,53 @@
+{
+  "status": "rejected",
+  "item_hash": "7091b61632e0385adb6978dccbec1da40e9c400ffac7233076a3ad0219f49de0",
+  "reception_time": "2023-12-03T16:00:53.432607+00:00",
+  "message": {
+    "time": 1701619253.309467,
+    "type": "INSTANCE",
+    "chain": "ETH",
+    "sender": "0x48A87924135892bEE2F264547a0D69909b3bA5C6",
+    "channel": null,
+    "content": {
+      "time": 1701619253.3092096,
+      "rootfs": {
+        "parent": {
+          "ref": "549ec451d9b099cad112d4aaa2c00ac40fb6729a92ff252ff22eef0b5c3cb613",
+          "use_latest": true
+        },
+        "size_mib": 2000,
+        "persistence": "host"
+      },
+      "address": "0x48A87924135892bEE2F264547a0D69909b3bA5C6",
+      "volumes": [],
+      "resources": {
+        "vcpus": 1,
+        "memory": 256,
+        "seconds": 30
+      },
+      "allow_amend": false,
+      "environment": {
+        "internet": true,
+        "aleph_api": true,
+        "reproducible": false,
+        "shared_cache": false
+      },
+      "authorized_keys": [
+        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCdU/B01GaUQ3l8aIt0XR6WajhM/5oTdxsON3b90quwQjH38Ba+Z3z74gf4+f56vxRw7XqtC8pg8zuh2L8+Fo3IHctULJD24YbLr2CagwrPsd9fsK+DsJSrcnTKaBBjvgloQi96hl4hPtlR9jA5bRYked0bFxdbFUMCmF17tpU0AC/dLeH3FwVDfh5dF11SX6ezg8brKd9SHYDRkOBHyOLIOWMtOgIgfEy9OsNdAS9OlOHyKxz4MEl5xkq5lRk9nS1n45A3rrIwi91qamjphHNrEutKaN/ramuW+davCP4xfnEVyu2DmoteDM+lmmf4skN90CwxhlrYpc5xpie5vTTYxgUCSnN0PyYiD0m7YHpZwMg1yHKB+aZghOIYUyKVJ8fIH/uU1DKwqcZ5qmH8sPvB4tCy3QOn7m7xTYVd/R3CECdG/R/55IUfGbg8KoAHBgmQ13/hSJ3IshMYOTWwMenma29D8UqKsyTfiMfof6Yf6NYOeDkAsUSIOEetxcv3MaE= mhh@mhh-TUXEDO"
+      ]
+    },
+    "item_hash": "7091b61632e0385adb6978dccbec1da40e9c400ffac7233076a3ad0219f49de0",
+    "item_type": "inline",
+    "signature": "0xa8e549c5228b379bede875016ed25215c6cd7c3e9131ec1b3bdb49af4859c8840251362c3c421995f520648026621245b4896c0a88d6a5735e5e2620812f22ff1b",
+    "item_content": "{\"address\":\"0x48A87924135892bEE2F264547a0D69909b3bA5C6\",\"time\":1701619253.3092096,\"allow_amend\":false,\"authorized_keys\":[\"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCdU/B01GaUQ3l8aIt0XR6WajhM/5oTdxsON3b90quwQjH38Ba+Z3z74gf4+f56vxRw7XqtC8pg8zuh2L8+Fo3IHctULJD24YbLr2CagwrPsd9fsK+DsJSrcnTKaBBjvgloQi96hl4hPtlR9jA5bRYked0bFxdbFUMCmF17tpU0AC/dLeH3FwVDfh5dF11SX6ezg8brKd9SHYDRkOBHyOLIOWMtOgIgfEy9OsNdAS9OlOHyKxz4MEl5xkq5lRk9nS1n45A3rrIwi91qamjphHNrEutKaN/ramuW+davCP4xfnEVyu2DmoteDM+lmmf4skN90CwxhlrYpc5xpie5vTTYxgUCSnN0PyYiD0m7YHpZwMg1yHKB+aZghOIYUyKVJ8fIH/uU1DKwqcZ5qmH8sPvB4tCy3QOn7m7xTYVd/R3CECdG/R/55IUfGbg8KoAHBgmQ13/hSJ3IshMYOTWwMenma29D8UqKsyTfiMfof6Yf6NYOeDkAsUSIOEetxcv3MaE= mhh@mhh-TUXEDO\"],\"environment\":{\"reproducible\":false,\"internet\":true,\"aleph_api\":true,\"shared_cache\":false},\"resources\":{\"vcpus\":1,\"memory\":256,\"seconds\":30},\"volumes\":[],\"rootfs\":{\"parent\":{\"ref\":\"549ec451d9b099cad112d4aaa2c00ac40fb6729a92ff252ff22eef0b5c3cb613\",\"use_latest\":true},\"persistence\":\"host\",\"size_mib\":2000}}"
+  },
+  "error_code": 5,
+  "details": {
+    "errors": [
+      {
+        "account_balance": "0",
+        "required_balance": "4213.265726725260407192763523"
+      }
+    ]
+  }
+}

--- a/tests/unit/test_asynchronous.py
+++ b/tests/unit/test_asynchronous.py
@@ -189,7 +189,7 @@ async def test_prepare_aleph_message(
 
 @pytest.mark.asyncio
 async def test_create_instance_insufficient_funds_error(
-    mock_session_with_rejected_message
+    mock_session_with_rejected_message,
 ):
     async with mock_session_with_rejected_message as session:
         with pytest.raises(InsufficientFundsError):

--- a/tests/unit/test_asynchronous_get.py
+++ b/tests/unit/test_asynchronous_get.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import pytest
 from aleph_message.models import MessagesResponse, MessageType
 
-from aleph.sdk.exceptions import ForgottenMessageError, InvalidMessageError
+from aleph.sdk.exceptions import ForgottenMessageError
 from aleph.sdk.query.filters import MessageFilter, PostFilter
 from aleph.sdk.query.responses import PostsResponse
 from tests.unit.conftest import make_mock_get_session
@@ -87,13 +87,13 @@ async def test_get_forgotten_message():
 
 @pytest.mark.asyncio
 async def test_get_message_error(rejected_message):
-    mock_session = make_mock_get_session(
-        rejected_message
-    )
+    mock_session = make_mock_get_session(rejected_message)
     async with mock_session as session:
         error = await session.get_message_error(rejected_message["item_hash"])
+        assert error
         assert error["error_code"] == rejected_message["error_code"]
         assert error["details"] == rejected_message["details"]
+
 
 if __name__ == "__main __":
     unittest.main()

--- a/tests/unit/test_asynchronous_get.py
+++ b/tests/unit/test_asynchronous_get.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import pytest
 from aleph_message.models import MessagesResponse, MessageType
 
-from aleph.sdk.exceptions import ForgottenMessageError
+from aleph.sdk.exceptions import ForgottenMessageError, InvalidMessageError
 from aleph.sdk.query.filters import MessageFilter, PostFilter
 from aleph.sdk.query.responses import PostsResponse
 from tests.unit.conftest import make_mock_get_session
@@ -84,6 +84,16 @@ async def test_get_forgotten_message():
         with pytest.raises(ForgottenMessageError):
             await session.get_message("cafebabe")
 
+
+@pytest.mark.asyncio
+async def test_get_message_error(rejected_message):
+    mock_session = make_mock_get_session(
+        rejected_message
+    )
+    async with mock_session as session:
+        error = await session.get_message_error(rejected_message["item_hash"])
+        assert error["error_code"] == rejected_message["error_code"]
+        assert error["details"] == rejected_message["details"]
 
 if __name__ == "__main __":
     unittest.main()


### PR DESCRIPTION
- Refactor `submit()` and `broadcast()` methods to add `raise_on_rejected` parameter. This allows client methods to implement their own exception handling on broadcast.
- Implement `InsufficientFundsError` if creating an instance failed due to low funds.