### PR TITLE
Increase default VM memory to 2000 MiB and add validation

### DIFF
--- a/src/aleph/sdk/client/authenticated_http.py
+++ b/src/aleph/sdk/client/authenticated_http.py
@@ -37,7 +37,12 @@ from aleph_message.status import MessageStatus
 from ..conf import settings
 from ..exceptions import BroadcastError, InsufficientFundsError, InvalidMessageError
 from ..types import Account, StorageEnum
-from ..utils import extended_json_encoder
+from ..utils import (
+    extended_json_encoder,
+    validate_memory,
+    validate_timeout,
+    validate_vcpus,
+)
 from .abstract import AuthenticatedAlephClient
 from .http import AlephHttpClient
 
@@ -432,12 +437,11 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
 
         volumes = volumes if volumes is not None else []
         memory = memory or settings.DEFAULT_VM_MEMORY
-        if memory < 2000:
-            raise ValueError("Minimum memory is 2000 MiB")
+        validate_memory(memory)
         vcpus = vcpus or settings.DEFAULT_VM_VCPUS
-        if vcpus < 1:
-            raise ValueError("Minimum vcpus is 1")
+        validate_vcpus(vcpus)
         timeout_seconds = timeout_seconds or settings.DEFAULT_VM_TIMEOUT
+        validate_timeout(timeout_seconds)
 
         # TODO: Check that program_ref, runtime and data_ref exist
 
@@ -529,12 +533,11 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
 
         volumes = volumes if volumes is not None else []
         memory = memory or settings.DEFAULT_VM_MEMORY
-        if memory < 2000:
-            raise ValueError("Minimum memory is 2000 MiB")
+        validate_memory(memory)
         vcpus = vcpus or settings.DEFAULT_VM_VCPUS
-        if vcpus < 1:
-            raise ValueError("Minimum vcpus is 1")
+        validate_vcpus(vcpus)
         timeout_seconds = timeout_seconds or settings.DEFAULT_VM_TIMEOUT
+        validate_timeout(timeout_seconds)
 
         content = InstanceContent(
             address=address,

--- a/src/aleph/sdk/client/authenticated_http.py
+++ b/src/aleph/sdk/client/authenticated_http.py
@@ -432,7 +432,11 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
 
         volumes = volumes if volumes is not None else []
         memory = memory or settings.DEFAULT_VM_MEMORY
+        if memory < 2000:
+            raise ValueError("Minimum memory is 2000 MiB")
         vcpus = vcpus or settings.DEFAULT_VM_VCPUS
+        if vcpus < 1:
+            raise ValueError("Minimum vcpus is 1")
         timeout_seconds = timeout_seconds or settings.DEFAULT_VM_TIMEOUT
 
         # TODO: Check that program_ref, runtime and data_ref exist
@@ -525,7 +529,11 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
 
         volumes = volumes if volumes is not None else []
         memory = memory or settings.DEFAULT_VM_MEMORY
+        if memory < 2000:
+            raise ValueError("Minimum memory is 2000 MiB")
         vcpus = vcpus or settings.DEFAULT_VM_VCPUS
+        if vcpus < 1:
+            raise ValueError("Minimum vcpus is 1")
         timeout_seconds = timeout_seconds or settings.DEFAULT_VM_TIMEOUT
 
         content = InstanceContent(

--- a/src/aleph/sdk/conf.py
+++ b/src/aleph/sdk/conf.py
@@ -30,7 +30,7 @@ class Settings(BaseSettings):
     ADDRESS_TO_USE: Optional[str] = None
 
     DEFAULT_RUNTIME_ID: str = "f873715dc2feec3833074bd4b8745363a0e0093746b987b4c8191268883b2463"  # Debian 12 official runtime
-    DEFAULT_VM_MEMORY: int = 256
+    DEFAULT_VM_MEMORY: int = 2000
     DEFAULT_VM_VCPUS: int = 1
     DEFAULT_VM_TIMEOUT: float = 30.0
 

--- a/src/aleph/sdk/utils.py
+++ b/src/aleph/sdk/utils.py
@@ -150,3 +150,24 @@ def extended_json_encoder(obj: Any) -> Any:
         return obj.hour * 3600 + obj.minute * 60 + obj.second + obj.microsecond / 1e6
     else:
         return pydantic_encoder(obj)
+
+
+def validate_vcpus(vcpus):
+    if vcpus < 1:
+        raise ValueError("Minimum vcpus is 1")
+    if vcpus > 4:
+        raise ValueError("Current maximum vcpus is 4")
+
+
+def validate_memory(memory):
+    if memory < 2000:
+        raise ValueError("Minimum memory is 2000 MiB")
+    if memory > 8000:
+        raise ValueError("Current maximum memory is 8000 MiB")
+
+
+def validate_timeout(timeout_seconds):
+    if timeout_seconds < 1:
+        raise ValueError("Minimum timeout is 1 second")
+    if timeout_seconds > 180:
+        raise ValueError("Current maximum timeout is 180 seconds")


### PR DESCRIPTION
- Increased `DEFAULT_VM_MEMORY` to 2000
- Raise `ValueError` if validation of either `memory`, `vcpus` or `timeout` has invalid values.

Suggested value ranges:
- 2000 MiB <= `memory` <= 8000 MiB
- 1 <= `vcpus` <= 4
- 1 <= `timeout` <= 180