### PR TITLE
Update docs to reflect v0.8.0 changes

### DIFF
--- a/docs/content/posts.rst
+++ b/docs/content/posts.rst
@@ -19,6 +19,19 @@ To get posts you have two options, either use the get_posts function, and get
 the posts in their amended state, or use get_message and only get the unique POST
 messages (with their content obviously).
 
+Since version 0.8.0, get_posts uses a PostFilter object to specify the filters:
+
+.. code-block:: python3
+
+    >>> from aleph.sdk.chains.sol import get_fallback_account
+    >>> from aleph.sdk.client import AuthenticatedAlephHttpClient
+    >>> from aleph.sdk.posts import PostFilter
+    >>> account = get_fallback_account()
+    >>> async with AuthenticatedAlephHttpClient(account) as client:
+    ...     posts, status = await client.get_posts(
+    ...         post_filter=PostFilter(channel='MY_CHANNEL')
+    ...     )
+
 
 Creating a Post
 ---------------

--- a/docs/content/posts.rst
+++ b/docs/content/posts.rst
@@ -16,7 +16,7 @@ Getting posts
 -------------
 
 To get posts you have two options, either use the get_posts function, and get
-the posts and their amends. Or use get_message and only get the unique POST
+the posts in their amended state, or use get_message and only get the unique POST
 messages (with their content obviously).
 
 
@@ -28,24 +28,72 @@ There is an helper for that: create_post.
 
 .. code-block:: python3
 
-    >>> from aleph_client.synchronous import create_post
-    >>> create_post(account, {'content': 'test'}, post_type='testtype', channel='MY_CHANNEL')
-    {'chain': 'NULS2',
-     'channel': 'MY_CHANNEL',
-     'sender': 'NULSd6HgaaV62iEcTZSWoaTrA3U7Jr7Vv1nXS',
-     'type': 'POST',
-     'time': 1573570575.281997,
-     'item_content': '{"type":"testtype","address":"NULSd6HgaaV62iEcTZSWoaTrA3U7Jr7Vv1nXS","content":{"content":"test"},"time":1573570575.2818618}',
-     'item_hash': '02afdbf33ff2c6ddb46349298a4598a8801cec61dbaa8f3a17ba9d1ad6dd8cb1',
-     'signature': 'G7yJjMCPgvX04Dd9rsz0oEuuRFa4PfuKAMOPA3Oblf6vd5YA1x15jvWLL2WycnnzYLEl0usjTiVxBl530ZOmYgw='}
-
-
-Asynchronous version is very similar:
-
-.. code-block:: python3
-
-    from aleph_client.asynchronous import create_post
-    await create_post(...)
+    >>> from aleph.sdk.chains.sol import get_fallback_account
+    >>> from aleph.sdk.client import AuthenticatedAlephHttpClient
+    >>> account = get_fallback_account()
+    >>> async with AuthenticatedAlephHttpClient(account) as client:
+    ...     post, status = await client.create_post({'content': 'test'}, post_type='testtype', channel='MY_CHANNEL')
+    >>> message
+    {
+        'chain': 'SOL',
+        'channel': 'MY_CHANNEL',
+        'sender': '21hKNCB7xmDZ1pgteuJPbhKN1aDvsvPJRJ5Q95G5gyCW',
+        'type': 'POST',
+        'time': '2023-07-11T13:20:14.604485+00:00',
+        'item_content': '{"type":"testtype","address":"21hKNCB7xmDZ1pgteuJPbhKN1aDvsvPJRJ5Q95G5gyCW","content":{"content":"test"},"time":1573570575.2818618}',
+        'content': {
+            'type': 'testtype',
+            'address': '21hKNCB7xmDZ1pgteuJPbhKN1aDvsvPJRJ5Q95G5gyCW',
+            'content': {
+                'content': 'test'
+            },
+            'time': 1573570575.2818618
+        },
+        'item_hash': '02afdbf33ff2c6ddb46349298a4598a8801cec61dbaa8f3a17ba9d1ad6dd8cb1',
+        'signature': 'G7yJjMCPgvX04Dd9rsz0oEuuRFa4PfuKAMOPA3Oblf6vd5YA1x15jvWLL2WycnnzYLEl0usjTiVxBl530ZOmYgw='
+    }
 
 Amending a Post
 ---------------
+
+Amending is as simple as creating a new post, but with two differences:
+
+- The post_type must be 'amend'
+- When calling create_post, you must pass the hash of the post you want to amend as 'ref'
+
+Example:
+
+.. code-block:: python3
+
+    >>> from aleph.sdk.chains.sol import get_fallback_account
+    >>> from aleph.sdk.client import AuthenticatedAlephHttpClient
+    >>> account = get_fallback_account()
+    >>> async with AuthenticatedAlephHttpClient(account) as client:
+    ...     post, status = await client.create_post({'content': 'test2'}, post_type='amend', ref='02afdbf33ff2c6ddb46349298a4598a8801cec61dbaa8f3a17ba9d1ad6dd8cb1', channel='MY_CHANNEL')
+    >>> message
+    {
+        'chain': 'SOL',
+        'channel': 'MY_CHANNEL',
+        'sender': '21hKNCB7xmDZ1pgteuJPbhKN1aDvsvPJRJ5Q95G5gyCW',
+        'type': 'POST',
+        'time': '2023-07-11T13:20:14.604485+00:00',
+        'item_content': '{"type":"amend","address":"21hKNCB7xmDZ1pgteuJPbhKN1aDvsvPJRJ5Q95G5gyCW","content":{"content":"test2"},"time":1573570575.2818618,"ref":"02afdbf33ff2c6ddb46349298a4598a8801cec61dbaa8f3a17ba9d1ad6dd8cb1"}',
+        'content': {
+            'type': 'amend',
+            'address': '21hKNCB7xmDZ1pgteuJPbhKN1aDvsvPJRJ5Q95G5gyCW',
+            'content': {
+                'content': 'test2'
+            },
+            'time': 1573570575.2818618,
+            'ref': '02afdbf33ff2c6ddb46349298a4598a8801cec61dbaa8f3a17ba9d1ad6dd8cb1'
+        },
+        'item_hash': '02afdbf33ff2c6ddb46349298a4598a8801cec61dbaa8f3a17ba9d1ad6dd8cb1',
+        'signature': 'G7yJjMCPgvX04Dd9rsz0oEuuRFa4PfuKAMOPA3Oblf6vd5YA1x15jvWLL2WycnnzYLEl0usjTiVxBl530ZOmYgw='
+    }
+
+
+.. note::
+
+    More information on posts and messages in general can be found in the
+    `pyaleph docs
+    <https://pyaleph.readthedocs.io/en/latest/protocol/messages/post.html>`_.


### PR DESCRIPTION
On a general note: I'd prefer to take the two changed pages for explaining how AGGREGATEs and POSTs work and put them into https://github.com/aleph-im/aleph-docs, while deprecating the docs here. This will entail changing all links to the old docs to the new pages.