### PR TITLE
Feature: Choose a ssl certificate other than the default one

### DIFF
--- a/src/aleph/sdk/client/authenticated_http.py
+++ b/src/aleph/sdk/client/authenticated_http.py
@@ -1,10 +1,10 @@
 import hashlib
 import json
 import logging
+import ssl
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, NoReturn, Optional, Tuple, Union
-import ssl
 
 import aiohttp
 from aleph_message import parse_message

--- a/src/aleph/sdk/client/authenticated_http.py
+++ b/src/aleph/sdk/client/authenticated_http.py
@@ -4,6 +4,7 @@ import logging
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, NoReturn, Optional, Tuple, Union
+import ssl
 
 import aiohttp
 from aleph_message import parse_message
@@ -66,18 +67,20 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
     }
 
     def __init__(
-        self,
-        account: Account,
-        api_server: Optional[str] = None,
-        api_unix_socket: Optional[str] = None,
-        allow_unix_sockets: bool = True,
-        timeout: Optional[aiohttp.ClientTimeout] = None,
+            self,
+            account: Account,
+            api_server: Optional[str] = None,
+            api_unix_socket: Optional[str] = None,
+            allow_unix_sockets: bool = True,
+            timeout: Optional[aiohttp.ClientTimeout] = None,
+            ssl_context: Optional[ssl.SSLContext] = None,
     ):
         super().__init__(
             api_server=api_server,
             api_unix_socket=api_unix_socket,
             allow_unix_sockets=allow_unix_sockets,
             timeout=timeout,
+            ssl_context=ssl_context,
         )
         self.account = account
 
@@ -192,8 +195,8 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
             raise BroadcastError(error_msg)
 
     async def _handle_broadcast_deprecated_response(
-        self,
-        response: aiohttp.ClientResponse,
+            self,
+            response: aiohttp.ClientResponse,
     ) -> None:
         if response.status != 200:
             await self._handle_broadcast_error(response)
@@ -210,16 +213,16 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         url = "/api/v0/ipfs/pubsub/pub"
         logger.debug(f"Posting message on {url}")
         async with self.http_session.post(
-            url,
-            json={
-                "topic": "ALEPH-TEST",
-                "data": message_dict,
-            },
+                url,
+                json={
+                    "topic": "ALEPH-TEST",
+                    "data": message_dict,
+                },
         ) as response:
             await self._handle_broadcast_deprecated_response(response)
 
     async def _handle_broadcast_response(
-        self, response: aiohttp.ClientResponse, sync: bool, raise_on_rejected: bool
+            self, response: aiohttp.ClientResponse, sync: bool, raise_on_rejected: bool
     ) -> Tuple[Dict[str, Any], MessageStatus]:
         if response.status in (200, 202):
             status = await response.json()
@@ -239,10 +242,10 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
             await self._handle_broadcast_error(response)
 
     async def _broadcast(
-        self,
-        message: AlephMessage,
-        sync: bool,
-        raise_on_rejected: bool = True,
+            self,
+            message: AlephMessage,
+            sync: bool,
+            raise_on_rejected: bool = True,
     ) -> Tuple[Dict[str, Any], MessageStatus]:
         """
         Broadcast a message on the aleph.im network.
@@ -256,11 +259,11 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
 
         message_dict = message.dict(include=self.BROADCAST_MESSAGE_FIELDS)
         async with self.http_session.post(
-            url,
-            json={
-                "sync": sync,
-                "message": message_dict,
-            },
+                url,
+                json={
+                    "sync": sync,
+                    "message": message_dict,
+                },
         ) as response:
             # The endpoint may be unavailable on this node, try the deprecated version.
             if response.status in (404, 405):
@@ -275,15 +278,15 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
                 )
 
     async def create_post(
-        self,
-        post_content,
-        post_type: str,
-        ref: Optional[str] = None,
-        address: Optional[str] = None,
-        channel: Optional[str] = None,
-        inline: bool = True,
-        storage_engine: StorageEnum = StorageEnum.storage,
-        sync: bool = False,
+            self,
+            post_content,
+            post_type: str,
+            ref: Optional[str] = None,
+            address: Optional[str] = None,
+            channel: Optional[str] = None,
+            inline: bool = True,
+            storage_engine: StorageEnum = StorageEnum.storage,
+            sync: bool = False,
     ) -> Tuple[PostMessage, MessageStatus]:
         address = address or settings.ADDRESS_TO_USE or self.account.get_address()
 
@@ -306,13 +309,13 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         return message, status
 
     async def create_aggregate(
-        self,
-        key: str,
-        content: Mapping[str, Any],
-        address: Optional[str] = None,
-        channel: Optional[str] = None,
-        inline: bool = True,
-        sync: bool = False,
+            self,
+            key: str,
+            content: Mapping[str, Any],
+            address: Optional[str] = None,
+            channel: Optional[str] = None,
+            inline: bool = True,
+            sync: bool = False,
     ) -> Tuple[AggregateMessage, MessageStatus]:
         address = address or settings.ADDRESS_TO_USE or self.account.get_address()
 
@@ -333,17 +336,17 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         return message, status
 
     async def create_store(
-        self,
-        address: Optional[str] = None,
-        file_content: Optional[bytes] = None,
-        file_path: Optional[Union[str, Path]] = None,
-        file_hash: Optional[str] = None,
-        guess_mime_type: bool = False,
-        ref: Optional[str] = None,
-        storage_engine: StorageEnum = StorageEnum.storage,
-        extra_fields: Optional[dict] = None,
-        channel: Optional[str] = None,
-        sync: bool = False,
+            self,
+            address: Optional[str] = None,
+            file_content: Optional[bytes] = None,
+            file_path: Optional[Union[str, Path]] = None,
+            file_hash: Optional[str] = None,
+            guess_mime_type: bool = False,
+            ref: Optional[str] = None,
+            storage_engine: StorageEnum = StorageEnum.storage,
+            extra_fields: Optional[dict] = None,
+            channel: Optional[str] = None,
+            sync: bool = False,
     ) -> Tuple[StoreMessage, MessageStatus]:
         address = address or settings.ADDRESS_TO_USE or self.account.get_address()
 
@@ -407,26 +410,26 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         return message, status
 
     async def create_program(
-        self,
-        program_ref: str,
-        entrypoint: str,
-        runtime: str,
-        environment_variables: Optional[Mapping[str, str]] = None,
-        storage_engine: StorageEnum = StorageEnum.storage,
-        channel: Optional[str] = None,
-        address: Optional[str] = None,
-        sync: bool = False,
-        memory: Optional[int] = None,
-        vcpus: Optional[int] = None,
-        timeout_seconds: Optional[float] = None,
-        persistent: bool = False,
-        allow_amend: bool = False,
-        internet: bool = True,
-        aleph_api: bool = True,
-        encoding: Encoding = Encoding.zip,
-        volumes: Optional[List[Mapping]] = None,
-        subscriptions: Optional[List[Mapping]] = None,
-        metadata: Optional[Mapping[str, Any]] = None,
+            self,
+            program_ref: str,
+            entrypoint: str,
+            runtime: str,
+            environment_variables: Optional[Mapping[str, str]] = None,
+            storage_engine: StorageEnum = StorageEnum.storage,
+            channel: Optional[str] = None,
+            address: Optional[str] = None,
+            sync: bool = False,
+            memory: Optional[int] = None,
+            vcpus: Optional[int] = None,
+            timeout_seconds: Optional[float] = None,
+            persistent: bool = False,
+            allow_amend: bool = False,
+            internet: bool = True,
+            aleph_api: bool = True,
+            encoding: Encoding = Encoding.zip,
+            volumes: Optional[List[Mapping]] = None,
+            subscriptions: Optional[List[Mapping]] = None,
+            metadata: Optional[Mapping[str, Any]] = None,
     ) -> Tuple[ProgramMessage, MessageStatus]:
         address = address or settings.ADDRESS_TO_USE or self.account.get_address()
 
@@ -500,26 +503,26 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         return message, status
 
     async def create_instance(
-        self,
-        rootfs: str,
-        rootfs_size: int,
-        rootfs_name: str,
-        environment_variables: Optional[Mapping[str, str]] = None,
-        storage_engine: StorageEnum = StorageEnum.storage,
-        channel: Optional[str] = None,
-        address: Optional[str] = None,
-        sync: bool = False,
-        memory: Optional[int] = None,
-        vcpus: Optional[int] = None,
-        timeout_seconds: Optional[float] = None,
-        allow_amend: bool = False,
-        internet: bool = True,
-        aleph_api: bool = True,
-        encoding: Encoding = Encoding.zip,
-        volumes: Optional[List[Mapping]] = None,
-        volume_persistence: str = "host",
-        ssh_keys: Optional[List[str]] = None,
-        metadata: Optional[Mapping[str, Any]] = None,
+            self,
+            rootfs: str,
+            rootfs_size: int,
+            rootfs_name: str,
+            environment_variables: Optional[Mapping[str, str]] = None,
+            storage_engine: StorageEnum = StorageEnum.storage,
+            channel: Optional[str] = None,
+            address: Optional[str] = None,
+            sync: bool = False,
+            memory: Optional[int] = None,
+            vcpus: Optional[int] = None,
+            timeout_seconds: Optional[float] = None,
+            allow_amend: bool = False,
+            internet: bool = True,
+            aleph_api: bool = True,
+            encoding: Encoding = Encoding.zip,
+            volumes: Optional[List[Mapping]] = None,
+            volume_persistence: str = "host",
+            ssh_keys: Optional[List[str]] = None,
+            metadata: Optional[Mapping[str, Any]] = None,
     ) -> Tuple[InstanceMessage, MessageStatus]:
         address = address or settings.ADDRESS_TO_USE or self.account.get_address()
 
@@ -591,13 +594,13 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
             raise ValueError(f"Unknown error code {error_code}: {rejected_message}")
 
     async def forget(
-        self,
-        hashes: List[str],
-        reason: Optional[str],
-        storage_engine: StorageEnum = StorageEnum.storage,
-        channel: Optional[str] = None,
-        address: Optional[str] = None,
-        sync: bool = False,
+            self,
+            hashes: List[str],
+            reason: Optional[str],
+            storage_engine: StorageEnum = StorageEnum.storage,
+            channel: Optional[str] = None,
+            address: Optional[str] = None,
+            sync: bool = False,
     ) -> Tuple[ForgetMessage, MessageStatus]:
         address = address or settings.ADDRESS_TO_USE or self.account.get_address()
 
@@ -625,12 +628,12 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         return h.hexdigest()
 
     async def _prepare_aleph_message(
-        self,
-        message_type: MessageType,
-        content: Dict[str, Any],
-        channel: Optional[str],
-        allow_inlining: bool = True,
-        storage_engine: StorageEnum = StorageEnum.storage,
+            self,
+            message_type: MessageType,
+            content: Dict[str, Any],
+            channel: Optional[str],
+            allow_inlining: bool = True,
+            storage_engine: StorageEnum = StorageEnum.storage,
     ) -> AlephMessage:
         message_dict: Dict[str, Any] = {
             "sender": self.account.get_address(),
@@ -667,14 +670,14 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         return parse_message(message_dict)
 
     async def submit(
-        self,
-        content: Dict[str, Any],
-        message_type: MessageType,
-        channel: Optional[str] = None,
-        storage_engine: StorageEnum = StorageEnum.storage,
-        allow_inlining: bool = True,
-        sync: bool = False,
-        raise_on_rejected: bool = True,
+            self,
+            content: Dict[str, Any],
+            message_type: MessageType,
+            channel: Optional[str] = None,
+            storage_engine: StorageEnum = StorageEnum.storage,
+            allow_inlining: bool = True,
+            sync: bool = False,
+            raise_on_rejected: bool = True,
     ) -> Tuple[AlephMessage, MessageStatus, Optional[Dict[str, Any]]]:
         message = await self._prepare_aleph_message(
             message_type=message_type,
@@ -689,11 +692,11 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         return message, message_status, response
 
     async def _storage_push_file_with_message(
-        self,
-        file_content: bytes,
-        store_content: StoreContent,
-        channel: Optional[str] = None,
-        sync: bool = False,
+            self,
+            file_content: bytes,
+            store_content: StoreContent,
+            channel: Optional[str] = None,
+            sync: bool = False,
     ) -> Tuple[StoreMessage, MessageStatus]:
         """Push a file to the storage service."""
         data = aiohttp.FormData()
@@ -727,14 +730,14 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
             return message, message_status
 
     async def _upload_file_native(
-        self,
-        address: str,
-        file_content: bytes,
-        guess_mime_type: bool = False,
-        ref: Optional[str] = None,
-        extra_fields: Optional[dict] = None,
-        channel: Optional[str] = None,
-        sync: bool = False,
+            self,
+            address: str,
+            file_content: bytes,
+            guess_mime_type: bool = False,
+            ref: Optional[str] = None,
+            extra_fields: Optional[dict] = None,
+            channel: Optional[str] = None,
+            sync: bool = False,
     ) -> Tuple[StoreMessage, MessageStatus]:
         file_hash = hashlib.sha256(file_content).hexdigest()
         if magic and guess_mime_type:

--- a/src/aleph/sdk/client/authenticated_http.py
+++ b/src/aleph/sdk/client/authenticated_http.py
@@ -67,13 +67,13 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
     }
 
     def __init__(
-            self,
-            account: Account,
-            api_server: Optional[str] = None,
-            api_unix_socket: Optional[str] = None,
-            allow_unix_sockets: bool = True,
-            timeout: Optional[aiohttp.ClientTimeout] = None,
-            ssl_context: Optional[ssl.SSLContext] = None,
+        self,
+        account: Account,
+        api_server: Optional[str] = None,
+        api_unix_socket: Optional[str] = None,
+        allow_unix_sockets: bool = True,
+        timeout: Optional[aiohttp.ClientTimeout] = None,
+        ssl_context: Optional[ssl.SSLContext] = None,
     ):
         super().__init__(
             api_server=api_server,
@@ -195,8 +195,8 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
             raise BroadcastError(error_msg)
 
     async def _handle_broadcast_deprecated_response(
-            self,
-            response: aiohttp.ClientResponse,
+        self,
+        response: aiohttp.ClientResponse,
     ) -> None:
         if response.status != 200:
             await self._handle_broadcast_error(response)
@@ -213,16 +213,16 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         url = "/api/v0/ipfs/pubsub/pub"
         logger.debug(f"Posting message on {url}")
         async with self.http_session.post(
-                url,
-                json={
-                    "topic": "ALEPH-TEST",
-                    "data": message_dict,
-                },
+            url,
+            json={
+                "topic": "ALEPH-TEST",
+                "data": message_dict,
+            },
         ) as response:
             await self._handle_broadcast_deprecated_response(response)
 
     async def _handle_broadcast_response(
-            self, response: aiohttp.ClientResponse, sync: bool, raise_on_rejected: bool
+        self, response: aiohttp.ClientResponse, sync: bool, raise_on_rejected: bool
     ) -> Tuple[Dict[str, Any], MessageStatus]:
         if response.status in (200, 202):
             status = await response.json()
@@ -242,10 +242,10 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
             await self._handle_broadcast_error(response)
 
     async def _broadcast(
-            self,
-            message: AlephMessage,
-            sync: bool,
-            raise_on_rejected: bool = True,
+        self,
+        message: AlephMessage,
+        sync: bool,
+        raise_on_rejected: bool = True,
     ) -> Tuple[Dict[str, Any], MessageStatus]:
         """
         Broadcast a message on the aleph.im network.
@@ -259,11 +259,11 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
 
         message_dict = message.dict(include=self.BROADCAST_MESSAGE_FIELDS)
         async with self.http_session.post(
-                url,
-                json={
-                    "sync": sync,
-                    "message": message_dict,
-                },
+            url,
+            json={
+                "sync": sync,
+                "message": message_dict,
+            },
         ) as response:
             # The endpoint may be unavailable on this node, try the deprecated version.
             if response.status in (404, 405):
@@ -278,15 +278,15 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
                 )
 
     async def create_post(
-            self,
-            post_content,
-            post_type: str,
-            ref: Optional[str] = None,
-            address: Optional[str] = None,
-            channel: Optional[str] = None,
-            inline: bool = True,
-            storage_engine: StorageEnum = StorageEnum.storage,
-            sync: bool = False,
+        self,
+        post_content,
+        post_type: str,
+        ref: Optional[str] = None,
+        address: Optional[str] = None,
+        channel: Optional[str] = None,
+        inline: bool = True,
+        storage_engine: StorageEnum = StorageEnum.storage,
+        sync: bool = False,
     ) -> Tuple[PostMessage, MessageStatus]:
         address = address or settings.ADDRESS_TO_USE or self.account.get_address()
 
@@ -309,13 +309,13 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         return message, status
 
     async def create_aggregate(
-            self,
-            key: str,
-            content: Mapping[str, Any],
-            address: Optional[str] = None,
-            channel: Optional[str] = None,
-            inline: bool = True,
-            sync: bool = False,
+        self,
+        key: str,
+        content: Mapping[str, Any],
+        address: Optional[str] = None,
+        channel: Optional[str] = None,
+        inline: bool = True,
+        sync: bool = False,
     ) -> Tuple[AggregateMessage, MessageStatus]:
         address = address or settings.ADDRESS_TO_USE or self.account.get_address()
 
@@ -336,17 +336,17 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         return message, status
 
     async def create_store(
-            self,
-            address: Optional[str] = None,
-            file_content: Optional[bytes] = None,
-            file_path: Optional[Union[str, Path]] = None,
-            file_hash: Optional[str] = None,
-            guess_mime_type: bool = False,
-            ref: Optional[str] = None,
-            storage_engine: StorageEnum = StorageEnum.storage,
-            extra_fields: Optional[dict] = None,
-            channel: Optional[str] = None,
-            sync: bool = False,
+        self,
+        address: Optional[str] = None,
+        file_content: Optional[bytes] = None,
+        file_path: Optional[Union[str, Path]] = None,
+        file_hash: Optional[str] = None,
+        guess_mime_type: bool = False,
+        ref: Optional[str] = None,
+        storage_engine: StorageEnum = StorageEnum.storage,
+        extra_fields: Optional[dict] = None,
+        channel: Optional[str] = None,
+        sync: bool = False,
     ) -> Tuple[StoreMessage, MessageStatus]:
         address = address or settings.ADDRESS_TO_USE or self.account.get_address()
 
@@ -410,26 +410,26 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         return message, status
 
     async def create_program(
-            self,
-            program_ref: str,
-            entrypoint: str,
-            runtime: str,
-            environment_variables: Optional[Mapping[str, str]] = None,
-            storage_engine: StorageEnum = StorageEnum.storage,
-            channel: Optional[str] = None,
-            address: Optional[str] = None,
-            sync: bool = False,
-            memory: Optional[int] = None,
-            vcpus: Optional[int] = None,
-            timeout_seconds: Optional[float] = None,
-            persistent: bool = False,
-            allow_amend: bool = False,
-            internet: bool = True,
-            aleph_api: bool = True,
-            encoding: Encoding = Encoding.zip,
-            volumes: Optional[List[Mapping]] = None,
-            subscriptions: Optional[List[Mapping]] = None,
-            metadata: Optional[Mapping[str, Any]] = None,
+        self,
+        program_ref: str,
+        entrypoint: str,
+        runtime: str,
+        environment_variables: Optional[Mapping[str, str]] = None,
+        storage_engine: StorageEnum = StorageEnum.storage,
+        channel: Optional[str] = None,
+        address: Optional[str] = None,
+        sync: bool = False,
+        memory: Optional[int] = None,
+        vcpus: Optional[int] = None,
+        timeout_seconds: Optional[float] = None,
+        persistent: bool = False,
+        allow_amend: bool = False,
+        internet: bool = True,
+        aleph_api: bool = True,
+        encoding: Encoding = Encoding.zip,
+        volumes: Optional[List[Mapping]] = None,
+        subscriptions: Optional[List[Mapping]] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
     ) -> Tuple[ProgramMessage, MessageStatus]:
         address = address or settings.ADDRESS_TO_USE or self.account.get_address()
 
@@ -503,26 +503,26 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         return message, status
 
     async def create_instance(
-            self,
-            rootfs: str,
-            rootfs_size: int,
-            rootfs_name: str,
-            environment_variables: Optional[Mapping[str, str]] = None,
-            storage_engine: StorageEnum = StorageEnum.storage,
-            channel: Optional[str] = None,
-            address: Optional[str] = None,
-            sync: bool = False,
-            memory: Optional[int] = None,
-            vcpus: Optional[int] = None,
-            timeout_seconds: Optional[float] = None,
-            allow_amend: bool = False,
-            internet: bool = True,
-            aleph_api: bool = True,
-            encoding: Encoding = Encoding.zip,
-            volumes: Optional[List[Mapping]] = None,
-            volume_persistence: str = "host",
-            ssh_keys: Optional[List[str]] = None,
-            metadata: Optional[Mapping[str, Any]] = None,
+        self,
+        rootfs: str,
+        rootfs_size: int,
+        rootfs_name: str,
+        environment_variables: Optional[Mapping[str, str]] = None,
+        storage_engine: StorageEnum = StorageEnum.storage,
+        channel: Optional[str] = None,
+        address: Optional[str] = None,
+        sync: bool = False,
+        memory: Optional[int] = None,
+        vcpus: Optional[int] = None,
+        timeout_seconds: Optional[float] = None,
+        allow_amend: bool = False,
+        internet: bool = True,
+        aleph_api: bool = True,
+        encoding: Encoding = Encoding.zip,
+        volumes: Optional[List[Mapping]] = None,
+        volume_persistence: str = "host",
+        ssh_keys: Optional[List[str]] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
     ) -> Tuple[InstanceMessage, MessageStatus]:
         address = address or settings.ADDRESS_TO_USE or self.account.get_address()
 
@@ -594,13 +594,13 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
             raise ValueError(f"Unknown error code {error_code}: {rejected_message}")
 
     async def forget(
-            self,
-            hashes: List[str],
-            reason: Optional[str],
-            storage_engine: StorageEnum = StorageEnum.storage,
-            channel: Optional[str] = None,
-            address: Optional[str] = None,
-            sync: bool = False,
+        self,
+        hashes: List[str],
+        reason: Optional[str],
+        storage_engine: StorageEnum = StorageEnum.storage,
+        channel: Optional[str] = None,
+        address: Optional[str] = None,
+        sync: bool = False,
     ) -> Tuple[ForgetMessage, MessageStatus]:
         address = address or settings.ADDRESS_TO_USE or self.account.get_address()
 
@@ -628,12 +628,12 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         return h.hexdigest()
 
     async def _prepare_aleph_message(
-            self,
-            message_type: MessageType,
-            content: Dict[str, Any],
-            channel: Optional[str],
-            allow_inlining: bool = True,
-            storage_engine: StorageEnum = StorageEnum.storage,
+        self,
+        message_type: MessageType,
+        content: Dict[str, Any],
+        channel: Optional[str],
+        allow_inlining: bool = True,
+        storage_engine: StorageEnum = StorageEnum.storage,
     ) -> AlephMessage:
         message_dict: Dict[str, Any] = {
             "sender": self.account.get_address(),
@@ -670,14 +670,14 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         return parse_message(message_dict)
 
     async def submit(
-            self,
-            content: Dict[str, Any],
-            message_type: MessageType,
-            channel: Optional[str] = None,
-            storage_engine: StorageEnum = StorageEnum.storage,
-            allow_inlining: bool = True,
-            sync: bool = False,
-            raise_on_rejected: bool = True,
+        self,
+        content: Dict[str, Any],
+        message_type: MessageType,
+        channel: Optional[str] = None,
+        storage_engine: StorageEnum = StorageEnum.storage,
+        allow_inlining: bool = True,
+        sync: bool = False,
+        raise_on_rejected: bool = True,
     ) -> Tuple[AlephMessage, MessageStatus, Optional[Dict[str, Any]]]:
         message = await self._prepare_aleph_message(
             message_type=message_type,
@@ -692,11 +692,11 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         return message, message_status, response
 
     async def _storage_push_file_with_message(
-            self,
-            file_content: bytes,
-            store_content: StoreContent,
-            channel: Optional[str] = None,
-            sync: bool = False,
+        self,
+        file_content: bytes,
+        store_content: StoreContent,
+        channel: Optional[str] = None,
+        sync: bool = False,
     ) -> Tuple[StoreMessage, MessageStatus]:
         """Push a file to the storage service."""
         data = aiohttp.FormData()
@@ -730,14 +730,14 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
             return message, message_status
 
     async def _upload_file_native(
-            self,
-            address: str,
-            file_content: bytes,
-            guess_mime_type: bool = False,
-            ref: Optional[str] = None,
-            extra_fields: Optional[dict] = None,
-            channel: Optional[str] = None,
-            sync: bool = False,
+        self,
+        address: str,
+        file_content: bytes,
+        guess_mime_type: bool = False,
+        ref: Optional[str] = None,
+        extra_fields: Optional[dict] = None,
+        channel: Optional[str] = None,
+        sync: bool = False,
     ) -> Tuple[StoreMessage, MessageStatus]:
         file_hash = hashlib.sha256(file_content).hexdigest()
         if magic and guess_mime_type:

--- a/src/aleph/sdk/client/http.py
+++ b/src/aleph/sdk/client/http.py
@@ -1,8 +1,8 @@
 import json
 import logging
-import ssl
 from io import BytesIO
 from typing import Any, AsyncIterable, Dict, Iterable, List, Optional, Type
+import ssl
 
 import aiohttp
 from aleph_message import parse_message
@@ -31,12 +31,12 @@ class AlephHttpClient(AlephClient):
     http_session: aiohttp.ClientSession
 
     def __init__(
-            self,
-            api_server: Optional[str] = None,
-            api_unix_socket: Optional[str] = None,
-            allow_unix_sockets: bool = True,
-            timeout: Optional[aiohttp.ClientTimeout] = None,
-            ssl_context: Optional[ssl.SSLContext] = None,
+        self,
+        api_server: Optional[str] = None,
+        api_unix_socket: Optional[str] = None,
+        allow_unix_sockets: bool = True,
+        timeout: Optional[aiohttp.ClientTimeout] = None,
+        ssl_context: Optional[ssl.SSLContext] = None,
     ):
         """AlephClient can use HTTP(S) or HTTP over Unix sockets.
         Unix sockets are used when running inside a virtual machine,
@@ -83,7 +83,7 @@ class AlephHttpClient(AlephClient):
         params: Dict[str, Any] = {"keys": key}
 
         async with self.http_session.get(
-                f"/api/v0/aggregates/{address}.json", params=params
+            f"/api/v0/aggregates/{address}.json", params=params
         ) as resp:
             resp.raise_for_status()
             result = await resp.json()
@@ -91,7 +91,7 @@ class AlephHttpClient(AlephClient):
             return data.get(key)
 
     async def fetch_aggregates(
-            self, address: str, keys: Optional[Iterable[str]] = None
+        self, address: str, keys: Optional[Iterable[str]] = None
     ) -> Dict[str, Dict]:
         keys_str = ",".join(keys) if keys else ""
         params: Dict[str, Any] = {}
@@ -99,8 +99,8 @@ class AlephHttpClient(AlephClient):
             params["keys"] = keys_str
 
         async with self.http_session.get(
-                f"/api/v0/aggregates/{address}.json",
-                params=params,
+            f"/api/v0/aggregates/{address}.json",
+            params=params,
         ) as resp:
             resp.raise_for_status()
             result = await resp.json()
@@ -108,12 +108,12 @@ class AlephHttpClient(AlephClient):
             return data
 
     async def get_posts(
-            self,
-            page_size: int = 200,
-            page: int = 1,
-            post_filter: Optional[PostFilter] = None,
-            ignore_invalid_messages: Optional[bool] = True,
-            invalid_messages_log_level: Optional[int] = logging.NOTSET,
+        self,
+        page_size: int = 200,
+        page: int = 1,
+        post_filter: Optional[PostFilter] = None,
+        ignore_invalid_messages: Optional[bool] = True,
+        invalid_messages_log_level: Optional[int] = logging.NOTSET,
     ) -> PostsResponse:
         ignore_invalid_messages = (
             True if ignore_invalid_messages is None else ignore_invalid_messages
@@ -157,9 +157,9 @@ class AlephHttpClient(AlephClient):
             )
 
     async def download_file_to_buffer(
-            self,
-            file_hash: str,
-            output_buffer: Writable[bytes],
+        self,
+        file_hash: str,
+        output_buffer: Writable[bytes],
     ) -> None:
         """
         Download a file from the storage engine and write it to the specified output buffer.
@@ -168,7 +168,7 @@ class AlephHttpClient(AlephClient):
         """
 
         async with self.http_session.get(
-                f"/api/v0/storage/raw/{file_hash}"
+            f"/api/v0/storage/raw/{file_hash}"
         ) as response:
             if response.status == 200:
                 await copy_async_readable_to_buffer(
@@ -184,9 +184,9 @@ class AlephHttpClient(AlephClient):
                     raise FileTooLarge(f"The file from {file_hash} is too large")
 
     async def download_file_ipfs_to_buffer(
-            self,
-            file_hash: str,
-            output_buffer: Writable[bytes],
+        self,
+        file_hash: str,
+        output_buffer: Writable[bytes],
     ) -> None:
         """
         Download a file from the storage engine and write it to the specified output buffer.
@@ -196,7 +196,7 @@ class AlephHttpClient(AlephClient):
         """
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                    f"https://ipfs.aleph.im/ipfs/{file_hash}"
+                f"https://ipfs.aleph.im/ipfs/{file_hash}"
             ) as response:
                 if response.status == 200:
                     await copy_async_readable_to_buffer(
@@ -206,8 +206,8 @@ class AlephHttpClient(AlephClient):
                     response.raise_for_status()
 
     async def download_file(
-            self,
-            file_hash: str,
+        self,
+        file_hash: str,
     ) -> bytes:
         """
         Get a file from the storage engine as raw bytes.
@@ -221,8 +221,8 @@ class AlephHttpClient(AlephClient):
         return buffer.getvalue()
 
     async def download_file_ipfs(
-            self,
-            file_hash: str,
+        self,
+        file_hash: str,
     ) -> bytes:
         """
         Get a file from the ipfs storage engine as raw bytes.
@@ -236,12 +236,12 @@ class AlephHttpClient(AlephClient):
         return buffer.getvalue()
 
     async def get_messages(
-            self,
-            page_size: int = 200,
-            page: int = 1,
-            message_filter: Optional[MessageFilter] = None,
-            ignore_invalid_messages: Optional[bool] = True,
-            invalid_messages_log_level: Optional[int] = logging.NOTSET,
+        self,
+        page_size: int = 200,
+        page: int = 1,
+        message_filter: Optional[MessageFilter] = None,
+        ignore_invalid_messages: Optional[bool] = True,
+        invalid_messages_log_level: Optional[int] = logging.NOTSET,
     ) -> MessagesResponse:
         ignore_invalid_messages = (
             True if ignore_invalid_messages is None else ignore_invalid_messages
@@ -263,7 +263,7 @@ class AlephHttpClient(AlephClient):
             params["pagination"] = str(page_size)
 
         async with self.http_session.get(
-                "/api/v0/messages.json", params=params
+            "/api/v0/messages.json", params=params
         ) as resp:
             resp.raise_for_status()
             response_json = await resp.json()
@@ -298,9 +298,9 @@ class AlephHttpClient(AlephClient):
             )
 
     async def get_message(
-            self,
-            item_hash: str,
-            message_type: Optional[Type[GenericMessage]] = None,
+        self,
+        item_hash: str,
+        message_type: Optional[Type[GenericMessage]] = None,
     ) -> GenericMessage:
         async with self.http_session.get(f"/api/v0/messages/{item_hash}") as resp:
             try:
@@ -325,8 +325,8 @@ class AlephHttpClient(AlephClient):
         return message
 
     async def get_message_error(
-            self,
-            item_hash: str,
+        self,
+        item_hash: str,
     ) -> Optional[Dict[str, Any]]:
         async with self.http_session.get(f"/api/v0/messages/{item_hash}") as resp:
             try:
@@ -348,14 +348,14 @@ class AlephHttpClient(AlephClient):
         }
 
     async def watch_messages(
-            self,
-            message_filter: Optional[MessageFilter] = None,
+        self,
+        message_filter: Optional[MessageFilter] = None,
     ) -> AsyncIterable[AlephMessage]:
         message_filter = message_filter or MessageFilter()
         params = message_filter.as_http_params()
 
         async with self.http_session.ws_connect(
-                "/api/ws0/messages", params=params
+            "/api/ws0/messages", params=params
         ) as ws:
             logger.debug("Websocket connected")
             async for msg in ws:

--- a/src/aleph/sdk/client/http.py
+++ b/src/aleph/sdk/client/http.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import ssl
 from io import BytesIO
 from typing import Any, AsyncIterable, Dict, Iterable, List, Optional, Type
 
@@ -30,11 +31,12 @@ class AlephHttpClient(AlephClient):
     http_session: aiohttp.ClientSession
 
     def __init__(
-        self,
-        api_server: Optional[str] = None,
-        api_unix_socket: Optional[str] = None,
-        allow_unix_sockets: bool = True,
-        timeout: Optional[aiohttp.ClientTimeout] = None,
+            self,
+            api_server: Optional[str] = None,
+            api_unix_socket: Optional[str] = None,
+            allow_unix_sockets: bool = True,
+            timeout: Optional[aiohttp.ClientTimeout] = None,
+            ssl_context: Optional[ssl.SSLContext] = None,
     ):
         """AlephClient can use HTTP(S) or HTTP over Unix sockets.
         Unix sockets are used when running inside a virtual machine,
@@ -48,6 +50,8 @@ class AlephHttpClient(AlephClient):
         if unix_socket_path and allow_unix_sockets:
             check_unix_socket_valid(unix_socket_path)
             connector = aiohttp.UnixConnector(path=unix_socket_path)
+        elif ssl_context:
+            connector = aiohttp.TCPConnector(ssl=ssl_context)
         else:
             connector = None
 
@@ -79,7 +83,7 @@ class AlephHttpClient(AlephClient):
         params: Dict[str, Any] = {"keys": key}
 
         async with self.http_session.get(
-            f"/api/v0/aggregates/{address}.json", params=params
+                f"/api/v0/aggregates/{address}.json", params=params
         ) as resp:
             resp.raise_for_status()
             result = await resp.json()
@@ -87,7 +91,7 @@ class AlephHttpClient(AlephClient):
             return data.get(key)
 
     async def fetch_aggregates(
-        self, address: str, keys: Optional[Iterable[str]] = None
+            self, address: str, keys: Optional[Iterable[str]] = None
     ) -> Dict[str, Dict]:
         keys_str = ",".join(keys) if keys else ""
         params: Dict[str, Any] = {}
@@ -95,8 +99,8 @@ class AlephHttpClient(AlephClient):
             params["keys"] = keys_str
 
         async with self.http_session.get(
-            f"/api/v0/aggregates/{address}.json",
-            params=params,
+                f"/api/v0/aggregates/{address}.json",
+                params=params,
         ) as resp:
             resp.raise_for_status()
             result = await resp.json()
@@ -104,12 +108,12 @@ class AlephHttpClient(AlephClient):
             return data
 
     async def get_posts(
-        self,
-        page_size: int = 200,
-        page: int = 1,
-        post_filter: Optional[PostFilter] = None,
-        ignore_invalid_messages: Optional[bool] = True,
-        invalid_messages_log_level: Optional[int] = logging.NOTSET,
+            self,
+            page_size: int = 200,
+            page: int = 1,
+            post_filter: Optional[PostFilter] = None,
+            ignore_invalid_messages: Optional[bool] = True,
+            invalid_messages_log_level: Optional[int] = logging.NOTSET,
     ) -> PostsResponse:
         ignore_invalid_messages = (
             True if ignore_invalid_messages is None else ignore_invalid_messages
@@ -153,9 +157,9 @@ class AlephHttpClient(AlephClient):
             )
 
     async def download_file_to_buffer(
-        self,
-        file_hash: str,
-        output_buffer: Writable[bytes],
+            self,
+            file_hash: str,
+            output_buffer: Writable[bytes],
     ) -> None:
         """
         Download a file from the storage engine and write it to the specified output buffer.
@@ -164,7 +168,7 @@ class AlephHttpClient(AlephClient):
         """
 
         async with self.http_session.get(
-            f"/api/v0/storage/raw/{file_hash}"
+                f"/api/v0/storage/raw/{file_hash}"
         ) as response:
             if response.status == 200:
                 await copy_async_readable_to_buffer(
@@ -180,9 +184,9 @@ class AlephHttpClient(AlephClient):
                     raise FileTooLarge(f"The file from {file_hash} is too large")
 
     async def download_file_ipfs_to_buffer(
-        self,
-        file_hash: str,
-        output_buffer: Writable[bytes],
+            self,
+            file_hash: str,
+            output_buffer: Writable[bytes],
     ) -> None:
         """
         Download a file from the storage engine and write it to the specified output buffer.
@@ -192,7 +196,7 @@ class AlephHttpClient(AlephClient):
         """
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                f"https://ipfs.aleph.im/ipfs/{file_hash}"
+                    f"https://ipfs.aleph.im/ipfs/{file_hash}"
             ) as response:
                 if response.status == 200:
                     await copy_async_readable_to_buffer(
@@ -202,8 +206,8 @@ class AlephHttpClient(AlephClient):
                     response.raise_for_status()
 
     async def download_file(
-        self,
-        file_hash: str,
+            self,
+            file_hash: str,
     ) -> bytes:
         """
         Get a file from the storage engine as raw bytes.
@@ -217,8 +221,8 @@ class AlephHttpClient(AlephClient):
         return buffer.getvalue()
 
     async def download_file_ipfs(
-        self,
-        file_hash: str,
+            self,
+            file_hash: str,
     ) -> bytes:
         """
         Get a file from the ipfs storage engine as raw bytes.
@@ -232,12 +236,12 @@ class AlephHttpClient(AlephClient):
         return buffer.getvalue()
 
     async def get_messages(
-        self,
-        page_size: int = 200,
-        page: int = 1,
-        message_filter: Optional[MessageFilter] = None,
-        ignore_invalid_messages: Optional[bool] = True,
-        invalid_messages_log_level: Optional[int] = logging.NOTSET,
+            self,
+            page_size: int = 200,
+            page: int = 1,
+            message_filter: Optional[MessageFilter] = None,
+            ignore_invalid_messages: Optional[bool] = True,
+            invalid_messages_log_level: Optional[int] = logging.NOTSET,
     ) -> MessagesResponse:
         ignore_invalid_messages = (
             True if ignore_invalid_messages is None else ignore_invalid_messages
@@ -259,7 +263,7 @@ class AlephHttpClient(AlephClient):
             params["pagination"] = str(page_size)
 
         async with self.http_session.get(
-            "/api/v0/messages.json", params=params
+                "/api/v0/messages.json", params=params
         ) as resp:
             resp.raise_for_status()
             response_json = await resp.json()
@@ -294,9 +298,9 @@ class AlephHttpClient(AlephClient):
             )
 
     async def get_message(
-        self,
-        item_hash: str,
-        message_type: Optional[Type[GenericMessage]] = None,
+            self,
+            item_hash: str,
+            message_type: Optional[Type[GenericMessage]] = None,
     ) -> GenericMessage:
         async with self.http_session.get(f"/api/v0/messages/{item_hash}") as resp:
             try:
@@ -321,8 +325,8 @@ class AlephHttpClient(AlephClient):
         return message
 
     async def get_message_error(
-        self,
-        item_hash: str,
+            self,
+            item_hash: str,
     ) -> Optional[Dict[str, Any]]:
         async with self.http_session.get(f"/api/v0/messages/{item_hash}") as resp:
             try:
@@ -344,14 +348,14 @@ class AlephHttpClient(AlephClient):
         }
 
     async def watch_messages(
-        self,
-        message_filter: Optional[MessageFilter] = None,
+            self,
+            message_filter: Optional[MessageFilter] = None,
     ) -> AsyncIterable[AlephMessage]:
         message_filter = message_filter or MessageFilter()
         params = message_filter.as_http_params()
 
         async with self.http_session.ws_connect(
-            "/api/ws0/messages", params=params
+                "/api/ws0/messages", params=params
         ) as ws:
             logger.debug("Websocket connected")
             async for msg in ws:

--- a/src/aleph/sdk/client/http.py
+++ b/src/aleph/sdk/client/http.py
@@ -47,11 +47,11 @@ class AlephHttpClient(AlephClient):
             raise ValueError("Missing API host")
 
         unix_socket_path = api_unix_socket or settings.API_UNIX_SOCKET
-        if unix_socket_path and allow_unix_sockets:
+        if ssl_context:
+            connector = aiohttp.TCPConnector(ssl=ssl_context)
+        elif unix_socket_path and allow_unix_sockets:
             check_unix_socket_valid(unix_socket_path)
             connector = aiohttp.UnixConnector(path=unix_socket_path)
-        elif ssl_context:
-            connector = aiohttp.TCPConnector(ssl=ssl_context)
         else:
             connector = None
 

--- a/src/aleph/sdk/client/http.py
+++ b/src/aleph/sdk/client/http.py
@@ -1,8 +1,8 @@
 import json
 import logging
-from io import BytesIO
-from typing import Any, AsyncIterable, Dict, Iterable, List, Optional, Type
 import ssl
+from io import BytesIO
+from typing import Any, AsyncIterable, Dict, Iterable, List, Optional, Type, Union
 
 import aiohttp
 from aleph_message import parse_message
@@ -46,6 +46,7 @@ class AlephHttpClient(AlephClient):
         if not self.api_server:
             raise ValueError("Missing API host")
 
+        connector: Union[aiohttp.BaseConnector, None]
         unix_socket_path = api_unix_socket or settings.API_UNIX_SOCKET
         if ssl_context:
             connector = aiohttp.TCPConnector(ssl=ssl_context)


### PR DESCRIPTION
I had the following problem:

```ssl:True [SSLCertVerificationError: (1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate```

when using the function: **AuthenticatedAlephHttpClient** and **AlephHttpClient**

I searched on the internet for a way to solve this problem, but all the commands/advice given didn't work.

So I thought it would be a good idea to give the user the option of specifying a specific SSL certificate if they wish.

This worked in my case and gave me the option of continuing to use the SDK provided by Aleph.