### PR TITLE
Fix: An ETH account could not be initialized from its mnemonic

### DIFF
--- a/src/aleph/sdk/chains/ethereum.py
+++ b/src/aleph/sdk/chains/ethereum.py
@@ -36,6 +36,11 @@ class ETHAccount(BaseAccount):
     def get_public_key(self) -> str:
         return "0x" + get_public_key(private_key=self._account.key).hex()
 
+    @staticmethod
+    def from_mnemonic(mnemonic: str) -> "ETHAccount":
+        Account.enable_unaudited_hdwallet_features()
+        return ETHAccount(private_key=Account.from_mnemonic(mnemonic=mnemonic).key)
+
 
 def get_fallback_account(path: Optional[Path] = None) -> ETHAccount:
     return ETHAccount(private_key=get_fallback_private_key(path=path))

--- a/tests/unit/test_chain_ethereum.py
+++ b/tests/unit/test_chain_ethereum.py
@@ -5,7 +5,7 @@ from tempfile import NamedTemporaryFile
 import pytest
 
 from aleph.sdk.chains.common import get_verification_buffer
-from aleph.sdk.chains.ethereum import get_fallback_account, verify_signature
+from aleph.sdk.chains.ethereum import get_fallback_account, verify_signature, ETHAccount
 from aleph.sdk.exceptions import BadSignatureError
 
 
@@ -156,3 +156,14 @@ async def test_sign_raw(ethereum_account):
     assert isinstance(signature, bytes)
 
     verify_signature(signature, ethereum_account.get_address(), buffer)
+
+
+def test_from_mnemonic():
+    mnemonic = (
+        "indoor dish desk flag debris potato excuse depart ticket judge file exit"
+    )
+    account = ETHAccount.from_mnemonic(mnemonic)
+    assert (
+        account.get_public_key()
+        == "0x0226cc24348fbe0c2912fbb0aa4408e089bb0ae488a88ac46bb13290629a737646"
+    )

--- a/tests/unit/test_chain_ethereum.py
+++ b/tests/unit/test_chain_ethereum.py
@@ -5,7 +5,7 @@ from tempfile import NamedTemporaryFile
 import pytest
 
 from aleph.sdk.chains.common import get_verification_buffer
-from aleph.sdk.chains.ethereum import get_fallback_account, verify_signature, ETHAccount
+from aleph.sdk.chains.ethereum import ETHAccount, get_fallback_account, verify_signature
 from aleph.sdk.exceptions import BadSignatureError
 
 


### PR DESCRIPTION
Users could not easily import or migrate accounts using their mnemonic representation.

Solution: Add a static method `from_mnemonic` on the `ETHAccount` class.

Discussion: This is a first step and this behaviour can be extended to more chains in the future.