### PR TITLE
Fix: `create_instance` required a program `encoding`

### DIFF
--- a/src/aleph/sdk/client/abstract.py
+++ b/src/aleph/sdk/client/abstract.py
@@ -363,7 +363,6 @@ class AuthenticatedAlephClient(AlephClient):
         allow_amend: bool = False,
         internet: bool = True,
         aleph_api: bool = True,
-        encoding: Encoding = Encoding.zip,
         volumes: Optional[List[Mapping]] = None,
         volume_persistence: str = "host",
         ssh_keys: Optional[List[str]] = None,

--- a/src/aleph/sdk/client/authenticated_http.py
+++ b/src/aleph/sdk/client/authenticated_http.py
@@ -515,7 +515,6 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         allow_amend: bool = False,
         internet: bool = True,
         aleph_api: bool = True,
-        encoding: Encoding = Encoding.zip,
         volumes: Optional[List[Mapping]] = None,
         volume_persistence: str = "host",
         ssh_keys: Optional[List[str]] = None,


### PR DESCRIPTION
Problem: Instances don't use program encodings. This argument was left from refactoring.

Solution: Drop the argument.