### PR TITLE
Feature: Add Deprecation Message

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     eciespy>=0.3.13; python_version>="3.11"
     typing_extensions
     typer
-    aleph-message==0.4.1
+    aleph-message~=0.4.2
     eth_account>=0.4.0
     # Required to fix a dependency issue with parsimonious and Python3.11
     eth_abi==4.0.0b2; python_version>="3.11"

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     eciespy>=0.3.13; python_version>="3.11"
     typing_extensions
     typer
-    aleph-message~=0.4.1
+    aleph-message~=0.4.2
     eth_account>=0.4.0
     # Required to fix a dependency issue with parsimonious and Python3.11
     eth_abi==4.0.0b2; python_version>="3.11"

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     eciespy>=0.3.13; python_version>="3.11"
     typing_extensions
     typer
-    aleph-message~=0.4.2
+    aleph-message~=0.4.3
     eth_account>=0.4.0
     # Required to fix a dependency issue with parsimonious and Python3.11
     eth_abi==4.0.0b2; python_version>="3.11"

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     eciespy>=0.3.13; python_version>="3.11"
     typing_extensions
     typer
-    aleph-message~=0.4.2
+    aleph-message~=0.4.1
     eth_account>=0.4.0
     # Required to fix a dependency issue with parsimonious and Python3.11
     eth_abi==4.0.0b2; python_version>="3.11"

--- a/src/aleph/sdk/__init__.py
+++ b/src/aleph/sdk/__init__.py
@@ -16,12 +16,18 @@ __all__ = ["AlephHttpClient", "AuthenticatedAlephHttpClient"]
 
 def __getattr__(name):
     if name == "AlephClient":
-        raise ImportError("AlephClient has been turned into an abstract class. Please use `AlephHttpClient` instead.")
+        raise ImportError(
+            "AlephClient has been turned into an abstract class. Please use `AlephHttpClient` instead."
+        )
     elif name == "AuthenticatedAlephClient":
-        raise ImportError("AuthenticatedAlephClient has been turned into an abstract class. Please use `AuthenticatedAlephHttpClient` instead.")
+        raise ImportError(
+            "AuthenticatedAlephClient has been turned into an abstract class. Please use `AuthenticatedAlephHttpClient` instead."
+        )
     elif name == "synchronous":
-        raise ImportError("The 'aleph.sdk.synchronous' type is deprecated and has been removed from the aleph SDK. Please use `aleph.sdk.client.AlephHttpClient` instead.")
+        raise ImportError(
+            "The 'aleph.sdk.synchronous' type is deprecated and has been removed from the aleph SDK. Please use `aleph.sdk.client.AlephHttpClient` instead."
+        )
     elif name == "asynchronous":
-        raise ImportError("The 'aleph.sdk.asynchronous' type is deprecated and has been removed from the aleph SDK. Please use `aleph.sdk.client.AlephHttpClient` instead.")
-    else:
-        super().__getattribute__(name)
+        raise ImportError(
+            "The 'aleph.sdk.asynchronous' type is deprecated and has been removed from the aleph SDK. Please use `aleph.sdk.client.AlephHttpClient` instead."
+        )

--- a/src/aleph/sdk/__init__.py
+++ b/src/aleph/sdk/__init__.py
@@ -16,10 +16,12 @@ __all__ = ["AlephHttpClient", "AuthenticatedAlephHttpClient"]
 
 def __getattr__(name):
     if name == "AlephClient":
-        raise ImportError(f"AlephClient has been turned into an abstract class. Please use `AlephHttpClient` instead.")
+        raise ImportError("AlephClient has been turned into an abstract class. Please use `AlephHttpClient` instead.")
     elif name == "AuthenticatedAlephClient":
-        raise ImportError(f"AuthenticatedAlephClient has been turned into an abstract class. Please use `AuthenticatedAlephHttpClient` instead.")
+        raise ImportError("AuthenticatedAlephClient has been turned into an abstract class. Please use `AuthenticatedAlephHttpClient` instead.")
     elif name == "synchronous":
-        raise ImportError(f"The 'aleph.sdk.synchronous' type is deprecated and has been removed from the aleph SDK. Please use `aleph.sdk.client.AlephHttpClient` instead.")
+        raise ImportError("The 'aleph.sdk.synchronous' type is deprecated and has been removed from the aleph SDK. Please use `aleph.sdk.client.AlephHttpClient` instead.")
     elif name == "asynchronous":
-        raise ImportError(f"The 'aleph.sdk.asynchronous' type is deprecated and has been removed from the aleph SDK. Please use `aleph.sdk.client.AlephHttpClient` instead.")
+        raise ImportError("The 'aleph.sdk.asynchronous' type is deprecated and has been removed from the aleph SDK. Please use `aleph.sdk.client.AlephHttpClient` instead.")
+    else:
+        super().__getattribute__(name)

--- a/src/aleph/sdk/__init__.py
+++ b/src/aleph/sdk/__init__.py
@@ -12,3 +12,14 @@ finally:
     del get_distribution, DistributionNotFound
 
 __all__ = ["AlephHttpClient", "AuthenticatedAlephHttpClient"]
+
+
+def __getattr__(name):
+    if name == "AlephClient":
+        raise ImportError(f"AlephClient has been turned into an abstract class. Please use `AlephHttpClient` instead.")
+    elif name == "AuthenticatedAlephClient":
+        raise ImportError(f"AuthenticatedAlephClient has been turned into an abstract class. Please use `AuthenticatedAlephHttpClient` instead.")
+    elif name == "synchronous":
+        raise ImportError(f"The 'aleph.sdk.synchronous' type is deprecated and has been removed from the aleph SDK. Please use `aleph.sdk.client.AlephHttpClient` instead.")
+    elif name == "asynchronous":
+        raise ImportError(f"The 'aleph.sdk.asynchronous' type is deprecated and has been removed from the aleph SDK. Please use `aleph.sdk.client.AlephHttpClient` instead.")

--- a/src/aleph/sdk/client/abstract.py
+++ b/src/aleph/sdk/client/abstract.py
@@ -42,7 +42,7 @@ class AlephClient(ABC):
         :param address: Address of the owner of the aggregate
         :param key: Key of the aggregate
         """
-        raise ImportError("Did you mean to import `AlephHttpClient`?")
+        raise NotImplementedError("Did you mean to import `AlephHttpClient`?")
 
     @abstractmethod
     async def fetch_aggregates(
@@ -54,7 +54,7 @@ class AlephClient(ABC):
         :param address: Address of the owner of the aggregate
         :param keys: Keys of the aggregates to fetch (Default: all items)
         """
-        raise ImportError("Did you mean to import `AlephHttpClient`?")
+        raise NotImplementedError("Did you mean to import `AlephHttpClient`?")
 
     @abstractmethod
     async def get_posts(
@@ -74,7 +74,7 @@ class AlephClient(ABC):
         :param ignore_invalid_messages: Ignore invalid messages (Default: True)
         :param invalid_messages_log_level: Log level to use for invalid messages (Default: logging.NOTSET)
         """
-        raise ImportError("Did you mean to import `AlephHttpClient`?")
+        raise NotImplementedError("Did you mean to import `AlephHttpClient`?")
 
     async def get_posts_iterator(
         self,
@@ -109,7 +109,7 @@ class AlephClient(ABC):
 
         :param file_hash: The hash of the file to retrieve.
         """
-        raise ImportError("Did you mean to import `AlephHttpClient`?")
+        raise NotImplementedError("Did you mean to import `AlephHttpClient`?")
 
     async def download_file_ipfs(
         self,
@@ -167,7 +167,7 @@ class AlephClient(ABC):
         :param ignore_invalid_messages: Ignore invalid messages (Default: True)
         :param invalid_messages_log_level: Log level to use for invalid messages (Default: logging.NOTSET)
         """
-        raise ImportError("Did you mean to import `AlephHttpClient`?")
+        raise NotImplementedError("Did you mean to import `AlephHttpClient`?")
 
     async def get_messages_iterator(
         self,
@@ -202,7 +202,7 @@ class AlephClient(ABC):
         :param item_hash: Hash of the message to fetch
         :param message_type: Type of message to fetch
         """
-        raise ImportError("Did you mean to import `AlephHttpClient`?")
+        raise NotImplementedError("Did you mean to import `AlephHttpClient`?")
 
     @abstractmethod
     def watch_messages(
@@ -214,7 +214,7 @@ class AlephClient(ABC):
 
         :param message_filter: Filter to apply to the messages
         """
-        raise ImportError("Did you mean to import `AlephHttpClient`?")
+        raise NotImplementedError("Did you mean to import `AlephHttpClient`?")
 
 
 class AuthenticatedAlephClient(AlephClient):
@@ -242,7 +242,7 @@ class AuthenticatedAlephClient(AlephClient):
         :param storage_engine: An optional storage engine to use for the message, if not inlined (Default: "storage")
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
         """
-        raise ImportError("Did you mean to import `AuthenticatedAlephHttpClient`?")
+        raise NotImplementedError("Did you mean to import `AuthenticatedAlephHttpClient`?")
 
     @abstractmethod
     async def create_aggregate(
@@ -264,7 +264,7 @@ class AuthenticatedAlephClient(AlephClient):
         :param inline: Whether to write content inside the message (Default: True)
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
         """
-        raise ImportError("Did you mean to import `AuthenticatedAlephHttpClient`?")
+        raise NotImplementedError("Did you mean to import `AuthenticatedAlephHttpClient`?")
 
     @abstractmethod
     async def create_store(
@@ -296,7 +296,7 @@ class AuthenticatedAlephClient(AlephClient):
         :param channel: Channel to post the message to (Default: "TEST")
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
         """
-        raise ImportError("Did you mean to import `AuthenticatedAlephHttpClient`?")
+        raise NotImplementedError("Did you mean to import `AuthenticatedAlephHttpClient`?")
 
     @abstractmethod
     async def create_program(
@@ -344,7 +344,7 @@ class AuthenticatedAlephClient(AlephClient):
         :param subscriptions: Patterns of aleph.im messages to forward to the program's event receiver
         :param metadata: Metadata to attach to the message
         """
-        raise ImportError("Did you mean to import `AuthenticatedAlephHttpClient`?")
+        raise NotImplementedError("Did you mean to import `AuthenticatedAlephHttpClient`?")
 
     @abstractmethod
     async def create_instance(
@@ -392,7 +392,7 @@ class AuthenticatedAlephClient(AlephClient):
         :param ssh_keys: SSH keys to authorize access to the VM
         :param metadata: Metadata to attach to the message
         """
-        raise ImportError("Did you mean to import `AuthenticatedAlephHttpClient`?")
+        raise NotImplementedError("Did you mean to import `AuthenticatedAlephHttpClient`?")
 
     @abstractmethod
     async def forget(
@@ -417,7 +417,7 @@ class AuthenticatedAlephClient(AlephClient):
         :param address: Address to use (Default: account.get_address())
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
         """
-        raise ImportError("Did you mean to import `AuthenticatedAlephHttpClient`?")
+        raise NotImplementedError("Did you mean to import `AuthenticatedAlephHttpClient`?")
 
     @abstractmethod
     async def submit(
@@ -442,7 +442,7 @@ class AuthenticatedAlephClient(AlephClient):
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
         :param raise_on_rejected: Whether to raise an exception if the message is rejected (Default: True)
         """
-        raise ImportError("Did you mean to import `AuthenticatedAlephHttpClient`?")
+        raise NotImplementedError("Did you mean to import `AuthenticatedAlephHttpClient`?")
 
     async def ipfs_push(self, content: Mapping) -> str:
         """

--- a/src/aleph/sdk/client/abstract.py
+++ b/src/aleph/sdk/client/abstract.py
@@ -242,7 +242,9 @@ class AuthenticatedAlephClient(AlephClient):
         :param storage_engine: An optional storage engine to use for the message, if not inlined (Default: "storage")
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
         """
-        raise NotImplementedError("Did you mean to import `AuthenticatedAlephHttpClient`?")
+        raise NotImplementedError(
+            "Did you mean to import `AuthenticatedAlephHttpClient`?"
+        )
 
     @abstractmethod
     async def create_aggregate(
@@ -264,7 +266,9 @@ class AuthenticatedAlephClient(AlephClient):
         :param inline: Whether to write content inside the message (Default: True)
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
         """
-        raise NotImplementedError("Did you mean to import `AuthenticatedAlephHttpClient`?")
+        raise NotImplementedError(
+            "Did you mean to import `AuthenticatedAlephHttpClient`?"
+        )
 
     @abstractmethod
     async def create_store(
@@ -296,7 +300,9 @@ class AuthenticatedAlephClient(AlephClient):
         :param channel: Channel to post the message to (Default: "TEST")
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
         """
-        raise NotImplementedError("Did you mean to import `AuthenticatedAlephHttpClient`?")
+        raise NotImplementedError(
+            "Did you mean to import `AuthenticatedAlephHttpClient`?"
+        )
 
     @abstractmethod
     async def create_program(
@@ -344,7 +350,9 @@ class AuthenticatedAlephClient(AlephClient):
         :param subscriptions: Patterns of aleph.im messages to forward to the program's event receiver
         :param metadata: Metadata to attach to the message
         """
-        raise NotImplementedError("Did you mean to import `AuthenticatedAlephHttpClient`?")
+        raise NotImplementedError(
+            "Did you mean to import `AuthenticatedAlephHttpClient`?"
+        )
 
     @abstractmethod
     async def create_instance(
@@ -392,7 +400,9 @@ class AuthenticatedAlephClient(AlephClient):
         :param ssh_keys: SSH keys to authorize access to the VM
         :param metadata: Metadata to attach to the message
         """
-        raise NotImplementedError("Did you mean to import `AuthenticatedAlephHttpClient`?")
+        raise NotImplementedError(
+            "Did you mean to import `AuthenticatedAlephHttpClient`?"
+        )
 
     @abstractmethod
     async def forget(
@@ -417,7 +427,9 @@ class AuthenticatedAlephClient(AlephClient):
         :param address: Address to use (Default: account.get_address())
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
         """
-        raise NotImplementedError("Did you mean to import `AuthenticatedAlephHttpClient`?")
+        raise NotImplementedError(
+            "Did you mean to import `AuthenticatedAlephHttpClient`?"
+        )
 
     @abstractmethod
     async def submit(
@@ -442,7 +454,9 @@ class AuthenticatedAlephClient(AlephClient):
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
         :param raise_on_rejected: Whether to raise an exception if the message is rejected (Default: True)
         """
-        raise NotImplementedError("Did you mean to import `AuthenticatedAlephHttpClient`?")
+        raise NotImplementedError(
+            "Did you mean to import `AuthenticatedAlephHttpClient`?"
+        )
 
     async def ipfs_push(self, content: Mapping) -> str:
         """

--- a/src/aleph/sdk/client/abstract.py
+++ b/src/aleph/sdk/client/abstract.py
@@ -42,7 +42,7 @@ class AlephClient(ABC):
         :param address: Address of the owner of the aggregate
         :param key: Key of the aggregate
         """
-        pass
+        raise ImportError("Did you mean to import `AlephHttpClient`?")
 
     @abstractmethod
     async def fetch_aggregates(
@@ -54,7 +54,7 @@ class AlephClient(ABC):
         :param address: Address of the owner of the aggregate
         :param keys: Keys of the aggregates to fetch (Default: all items)
         """
-        pass
+        raise ImportError("Did you mean to import `AlephHttpClient`?")
 
     @abstractmethod
     async def get_posts(
@@ -74,7 +74,7 @@ class AlephClient(ABC):
         :param ignore_invalid_messages: Ignore invalid messages (Default: True)
         :param invalid_messages_log_level: Log level to use for invalid messages (Default: logging.NOTSET)
         """
-        pass
+        raise ImportError("Did you mean to import `AlephHttpClient`?")
 
     async def get_posts_iterator(
         self,
@@ -109,7 +109,7 @@ class AlephClient(ABC):
 
         :param file_hash: The hash of the file to retrieve.
         """
-        pass
+        raise ImportError("Did you mean to import `AlephHttpClient`?")
 
     async def download_file_ipfs(
         self,
@@ -167,7 +167,7 @@ class AlephClient(ABC):
         :param ignore_invalid_messages: Ignore invalid messages (Default: True)
         :param invalid_messages_log_level: Log level to use for invalid messages (Default: logging.NOTSET)
         """
-        pass
+        raise ImportError("Did you mean to import `AlephHttpClient`?")
 
     async def get_messages_iterator(
         self,
@@ -202,7 +202,7 @@ class AlephClient(ABC):
         :param item_hash: Hash of the message to fetch
         :param message_type: Type of message to fetch
         """
-        pass
+        raise ImportError("Did you mean to import `AlephHttpClient`?")
 
     @abstractmethod
     def watch_messages(
@@ -214,7 +214,7 @@ class AlephClient(ABC):
 
         :param message_filter: Filter to apply to the messages
         """
-        pass
+        raise ImportError("Did you mean to import `AlephHttpClient`?")
 
 
 class AuthenticatedAlephClient(AlephClient):
@@ -242,7 +242,7 @@ class AuthenticatedAlephClient(AlephClient):
         :param storage_engine: An optional storage engine to use for the message, if not inlined (Default: "storage")
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
         """
-        pass
+        raise ImportError("Did you mean to import `AuthenticatedAlephHttpClient`?")
 
     @abstractmethod
     async def create_aggregate(
@@ -264,7 +264,7 @@ class AuthenticatedAlephClient(AlephClient):
         :param inline: Whether to write content inside the message (Default: True)
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
         """
-        pass
+        raise ImportError("Did you mean to import `AuthenticatedAlephHttpClient`?")
 
     @abstractmethod
     async def create_store(
@@ -296,7 +296,7 @@ class AuthenticatedAlephClient(AlephClient):
         :param channel: Channel to post the message to (Default: "TEST")
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
         """
-        pass
+        raise ImportError("Did you mean to import `AuthenticatedAlephHttpClient`?")
 
     @abstractmethod
     async def create_program(
@@ -344,7 +344,7 @@ class AuthenticatedAlephClient(AlephClient):
         :param subscriptions: Patterns of aleph.im messages to forward to the program's event receiver
         :param metadata: Metadata to attach to the message
         """
-        pass
+        raise ImportError("Did you mean to import `AuthenticatedAlephHttpClient`?")
 
     @abstractmethod
     async def create_instance(
@@ -392,7 +392,7 @@ class AuthenticatedAlephClient(AlephClient):
         :param ssh_keys: SSH keys to authorize access to the VM
         :param metadata: Metadata to attach to the message
         """
-        pass
+        raise ImportError("Did you mean to import `AuthenticatedAlephHttpClient`?")
 
     @abstractmethod
     async def forget(
@@ -417,7 +417,7 @@ class AuthenticatedAlephClient(AlephClient):
         :param address: Address to use (Default: account.get_address())
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
         """
-        pass
+        raise ImportError("Did you mean to import `AuthenticatedAlephHttpClient`?")
 
     @abstractmethod
     async def submit(
@@ -442,7 +442,7 @@ class AuthenticatedAlephClient(AlephClient):
         :param sync: If true, waits for the message to be processed by the API server (Default: False)
         :param raise_on_rejected: Whether to raise an exception if the message is rejected (Default: True)
         """
-        pass
+        raise ImportError("Did you mean to import `AuthenticatedAlephHttpClient`?")
 
     async def ipfs_push(self, content: Mapping) -> str:
         """

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,5 +1,23 @@
+import pytest
+
 from aleph.sdk import __version__
 
 
 def test_version():
     assert __version__ != ""
+
+
+def test_deprecation():
+    with pytest.raises(ImportError):
+        from aleph.sdk import AlephClient
+
+    with pytest.raises(ImportError):
+        from aleph.sdk import AuthenticatedAlephClient
+
+    with pytest.raises(ImportError):
+        from aleph.sdk import synchronous
+
+    with pytest.raises(ImportError):
+        from aleph.sdk import asynchronous
+
+    from aleph.sdk import AlephHttpClient

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -9,15 +9,21 @@ def test_version():
 
 def test_deprecation():
     with pytest.raises(ImportError):
-        from aleph.sdk import AlephClient
+        from aleph.sdk import AlephClient  # noqa
 
     with pytest.raises(ImportError):
-        from aleph.sdk import AuthenticatedAlephClient
+        from aleph.sdk import AuthenticatedAlephClient  # noqa
 
     with pytest.raises(ImportError):
-        from aleph.sdk import synchronous
+        from aleph.sdk import synchronous  # noqa
 
     with pytest.raises(ImportError):
-        from aleph.sdk import asynchronous
+        from aleph.sdk import asynchronous  # noqa
 
-    from aleph.sdk import AlephHttpClient
+    with pytest.raises(ImportError):
+        import aleph.sdk.synchronous  # noqa
+
+    with pytest.raises(ImportError):
+        import aleph.sdk.asynchronous  # noqa
+
+    from aleph.sdk import AlephHttpClient  # noqa


### PR DESCRIPTION
Deprecation messages are displayed when either trying to use the now abstract classes `AlephClient` and `AuthenticatedAlephClient` in the form of either
- `ImportError` when imported directly from `aleph.sdk`
- or `NotImplementedError` when imported from their source files, with additional info about which classes to use instead.