### PR TITLE
Loosen eth-abi dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ nuls2 =
 ethereum =
     eth_account>=0.4.0
     # Required to fix a dependency issue with parsimonious and Python3.11
-    eth_abi==4.0.0b2; python_version>="3.11"
+    eth_abi>=4.0.0; python_version>="3.11"
 polkadot =
     substrate-interface
     py-sr25519-bindings

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     aleph-message~=0.4.3
     eth_account>=0.4.0
     # Required to fix a dependency issue with parsimonious and Python3.11
-    eth_abi==4.0.0b2; python_version>="3.11"
+    eth_abi>=4.0.0; python_version>="3.11"
     python-magic
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov


### PR DESCRIPTION
Problem: Too strict of a eth-abi==4.0.0b2 dependency makes it difficult to install the latest version of the SDK on aleph-nodestatus.
![Screenshot from 2024-03-13 12-32-26](https://github.com/aleph-im/aleph-sdk-python/assets/70762838/d9e53f78-09f5-4f4c-89b3-2b213cf935a0)
