### PR TITLE
Remove double declaration of ethereum dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,9 +39,6 @@ install_requires =
     typing_extensions
     typer
     aleph-message~=0.4.3
-    eth_account>=0.4.0
-    # Required to fix a dependency issue with parsimonious and Python3.11
-    eth_abi>=4.0.0; python_version>="3.11"
     python-magic
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov


### PR DESCRIPTION
Now only required if installed with `pip install aleph-sdk-python[ethereum]`.