### PR TITLE
Deprecate encryption methods and make eciespy dependency optional

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,6 @@ install_requires =
     coincurve; python_version<"3.11"
     coincurve>=17.0.0; python_version>="3.11"   # Technically, this should be >=18.0.0 but there is a conflict with eciespy
     aiohttp>=3.8.3
-    eciespy; python_version<"3.11"
-    eciespy>=0.3.13; python_version>="3.11"
     typing_extensions
     typer
     aleph-message~=0.4.3
@@ -110,6 +108,9 @@ ledger =
     ledgereth==0.9.0
 docs =
     sphinxcontrib-plantuml
+encryption =
+    eciespy; python_version<"3.11"
+    eciespy>=0.3.13; python_version>="3.11"
 
 [options.entry_points]
 # Add here console scripts like:

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,8 @@ testing =
     py-sr25519-bindings
     ledgereth==0.9.0
     aiodns
+    eciespy; python_version<"3.11"
+    eciespy>=0.3.13; python_version>="3.11"
 dns =
     aiodns
 mqtt =

--- a/src/aleph/sdk/chains/common.py
+++ b/src/aleph/sdk/chains/common.py
@@ -2,9 +2,9 @@ import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Dict, Optional
+from typing_extensions import deprecated
 
 from coincurve.keys import PrivateKey
-from ecies import decrypt, encrypt
 
 from aleph.sdk.conf import settings
 from aleph.sdk.utils import enum_as_str
@@ -100,6 +100,7 @@ class BaseAccount(ABC):
         """
         raise NotImplementedError
 
+    @deprecated("This method will be moved to its own module `aleph.sdk.encryption`")
     async def encrypt(self, content: bytes) -> bytes:
         """
         Encrypts a message using the account's public key.
@@ -108,12 +109,17 @@ class BaseAccount(ABC):
         Returns:
             bytes: Encrypted content as bytes
         """
+        try:
+            from ecies import encrypt
+        except ImportError:
+            raise ImportError("Install `eciespy` or `aleph-sdk-python[encryption]` to use this method")
         if self.CURVE == "secp256k1":
             value: bytes = encrypt(self.get_public_key(), content)
             return value
         else:
             raise NotImplementedError
 
+    @deprecated("This method will be moved to its own module `aleph.sdk.encryption`")
     async def decrypt(self, content: bytes) -> bytes:
         """
         Decrypts a message using the account's private key.
@@ -122,6 +128,10 @@ class BaseAccount(ABC):
         Returns:
             bytes: Decrypted content as bytes
         """
+        try:
+            from ecies import decrypt
+        except ImportError:
+            raise ImportError("Install `eciespy` or `aleph-sdk-python[encryption]` to use this method")
         if self.CURVE == "secp256k1":
             value: bytes = decrypt(self.private_key, content)
             return value

--- a/src/aleph/sdk/chains/common.py
+++ b/src/aleph/sdk/chains/common.py
@@ -2,9 +2,9 @@ import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Dict, Optional
-from typing_extensions import deprecated
 
 from coincurve.keys import PrivateKey
+from typing_extensions import deprecated
 
 from aleph.sdk.conf import settings
 from aleph.sdk.utils import enum_as_str
@@ -112,7 +112,9 @@ class BaseAccount(ABC):
         try:
             from ecies import encrypt
         except ImportError:
-            raise ImportError("Install `eciespy` or `aleph-sdk-python[encryption]` to use this method")
+            raise ImportError(
+                "Install `eciespy` or `aleph-sdk-python[encryption]` to use this method"
+            )
         if self.CURVE == "secp256k1":
             value: bytes = encrypt(self.get_public_key(), content)
             return value
@@ -131,7 +133,9 @@ class BaseAccount(ABC):
         try:
             from ecies import decrypt
         except ImportError:
-            raise ImportError("Install `eciespy` or `aleph-sdk-python[encryption]` to use this method")
+            raise ImportError(
+                "Install `eciespy` or `aleph-sdk-python[encryption]` to use this method"
+            )
         if self.CURVE == "secp256k1":
             value: bytes = decrypt(self.private_key, content)
             return value


### PR DESCRIPTION
`eciespy` is not actively maintained anymore and may cause problems when installed alongside newer versions of web3py and ethereum-related packages.

The solution makes installing eciespy optional, deprecates the `Account.encrypt()` and `.decrypt()` functions and will move them in future to their own `aleph.sdk.encryption` module.