### PR TITLE
Removed `rootfs_name` instance creation field

### DIFF
--- a/src/aleph/sdk/client/abstract.py
+++ b/src/aleph/sdk/client/abstract.py
@@ -361,7 +361,6 @@ class AuthenticatedAlephClient(AlephClient):
         self,
         rootfs: str,
         rootfs_size: int,
-        rootfs_name: str,
         payment: Optional[Payment] = None,
         environment_variables: Optional[Mapping[str, str]] = None,
         storage_engine: StorageEnum = StorageEnum.storage,
@@ -385,7 +384,6 @@ class AuthenticatedAlephClient(AlephClient):
 
         :param rootfs: Root filesystem to use
         :param rootfs_size: Size of root filesystem
-        :param rootfs_name: Name of root filesystem
         :param payment: Payment method used to pay for the instance
         :param environment_variables: Environment variables to pass to the program
         :param storage_engine: Storage engine to use (Default: "storage")

--- a/src/aleph/sdk/client/authenticated_http.py
+++ b/src/aleph/sdk/client/authenticated_http.py
@@ -508,7 +508,6 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         self,
         rootfs: str,
         rootfs_size: int,
-        rootfs_name: str,
         payment: Optional[Payment] = None,
         environment_variables: Optional[Mapping[str, str]] = None,
         storage_engine: StorageEnum = StorageEnum.storage,
@@ -557,15 +556,9 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
                     ref=rootfs,
                     use_latest=True,
                 ),
-                name=rootfs_name,
                 size_mib=rootfs_size,
                 persistence="host",
                 use_latest=True,
-                comment=(
-                    "Official Aleph Debian root filesystem"
-                    if rootfs == settings.DEFAULT_RUNTIME_ID
-                    else ""
-                ),
             ),
             volumes=[parse_volume(volume) for volume in volumes],
             time=time.time(),

--- a/tests/unit/test_asynchronous.py
+++ b/tests/unit/test_asynchronous.py
@@ -108,7 +108,6 @@ async def test_create_instance(mock_session_with_post_success):
         instance_message, message_status = await session.create_instance(
             rootfs="cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
             rootfs_size=1,
-            rootfs_name="rootfs",
             channel="TEST",
             metadata={"tags": ["test"]},
             payment=Payment(
@@ -132,7 +131,6 @@ async def test_create_instance_no_payment(mock_session_with_post_success):
         instance_message, message_status = await session.create_instance(
             rootfs="cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
             rootfs_size=1,
-            rootfs_name="rootfs",
             channel="TEST",
             metadata={"tags": ["test"]},
             payment=None,
@@ -154,7 +152,6 @@ async def test_create_instance_no_hypervisor(mock_session_with_post_success):
         instance_message, message_status = await session.create_instance(
             rootfs="cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
             rootfs_size=1,
-            rootfs_name="rootfs",
             channel="TEST",
             metadata={"tags": ["test"]},
             hypervisor=None,
@@ -248,7 +245,6 @@ async def test_create_instance_insufficient_funds_error(
             await session.create_instance(
                 rootfs="cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
                 rootfs_size=1,
-                rootfs_name="rootfs",
                 channel="TEST",
                 metadata={"tags": ["test"]},
                 payment=Payment(


### PR DESCRIPTION
Problem: Using the `create_instance` method need to have the `rootfs_name` field filled, that finally is ignored on the final message.

Solution: Removed `rootfs_name` instance creation field. 