### PR TITLE
Add security module: Verify messages on fetch

### DIFF
--- a/src/aleph/sdk/client/abstract.py
+++ b/src/aleph/sdk/client/abstract.py
@@ -74,6 +74,7 @@ class AlephClient(ABC):
         post_filter: Optional[PostFilter] = None,
         ignore_invalid_messages: Optional[bool] = True,
         invalid_messages_log_level: Optional[int] = logging.NOTSET,
+        verify_signatures: bool = False,
     ) -> PostsResponse:
         """
         Fetch a list of posts from the network.
@@ -83,18 +84,25 @@ class AlephClient(ABC):
         :param post_filter: Filter to apply to the posts (Default: None)
         :param ignore_invalid_messages: Ignore invalid messages (Default: True)
         :param invalid_messages_log_level: Log level to use for invalid messages (Default: logging.NOTSET)
+        :param verify_signatures: Verify the signatures of the messages (Default: False)
         """
         raise NotImplementedError("Did you mean to import `AlephHttpClient`?")
 
     async def get_posts_iterator(
         self,
         post_filter: Optional[PostFilter] = None,
+        ignore_invalid_messages: Optional[bool] = True,
+        invalid_messages_log_level: Optional[int] = logging.NOTSET,
+        verify_signatures: bool = False,
     ) -> AsyncIterable[PostMessage]:
         """
         Fetch all filtered posts, returning an async iterator and fetching them page by page. Might return duplicates
         but will always return all posts.
 
         :param post_filter: Filter to apply to the posts (Default: None)
+        :param ignore_invalid_messages: Ignore invalid messages (Default: True)
+        :param invalid_messages_log_level: Log level to use for invalid messages (Default: logging.NOTSET)
+        :param verify_signatures: Verify the signatures of the messages (Default: False)
         """
         page = 1
         resp = None
@@ -102,6 +110,9 @@ class AlephClient(ABC):
             resp = await self.get_posts(
                 page=page,
                 post_filter=post_filter,
+                ignore_invalid_messages=ignore_invalid_messages,
+                invalid_messages_log_level=invalid_messages_log_level,
+                verify_signatures=verify_signatures,
             )
             page += 1
             for post in resp.posts:
@@ -178,6 +189,7 @@ class AlephClient(ABC):
         message_filter: Optional[MessageFilter] = None,
         ignore_invalid_messages: Optional[bool] = True,
         invalid_messages_log_level: Optional[int] = logging.NOTSET,
+        verify_signatures: bool = False,
     ) -> MessagesResponse:
         """
         Fetch a list of messages from the network.
@@ -187,18 +199,25 @@ class AlephClient(ABC):
         :param message_filter: Filter to apply to the messages
         :param ignore_invalid_messages: Ignore invalid messages (Default: True)
         :param invalid_messages_log_level: Log level to use for invalid messages (Default: logging.NOTSET)
+        :param verify_signatures: Verify the signatures of the messages (Default: False)
         """
         raise NotImplementedError("Did you mean to import `AlephHttpClient`?")
 
     async def get_messages_iterator(
         self,
         message_filter: Optional[MessageFilter] = None,
+        ignore_invalid_messages: Optional[bool] = True,
+        invalid_messages_log_level: Optional[int] = logging.NOTSET,
+        verify_signatures: bool = False,
     ) -> AsyncIterable[AlephMessage]:
         """
         Fetch all filtered messages, returning an async iterator and fetching them page by page. Might return duplicates
         but will always return all messages.
 
         :param message_filter: Filter to apply to the messages
+        :param ignore_invalid_messages: Ignore invalid messages (Default: True)
+        :param invalid_messages_log_level: Log level to use for invalid messages (Default: logging.NOTSET)
+        :param verify_signatures: Whether to verify the signatures of the messages (Default: False)
         """
         page = 1
         resp = None
@@ -206,6 +225,9 @@ class AlephClient(ABC):
             resp = await self.get_messages(
                 page=page,
                 message_filter=message_filter,
+                ignore_invalid_messages=ignore_invalid_messages,
+                invalid_messages_log_level=invalid_messages_log_level,
+                verify_signatures=verify_signatures,
             )
             page += 1
             for message in resp.messages:
@@ -216,12 +238,14 @@ class AlephClient(ABC):
         self,
         item_hash: str,
         message_type: Optional[Type[GenericMessage]] = None,
+        verify_signature: bool = False,
     ) -> GenericMessage:
         """
         Get a single message from its `item_hash` and perform some basic validation.
 
         :param item_hash: Hash of the message to fetch
         :param message_type: Type of message to fetch
+        :param verify_signature: Whether to verify the signature of the message (Default: False)
         """
         raise NotImplementedError("Did you mean to import `AlephHttpClient`?")
 
@@ -229,11 +253,13 @@ class AlephClient(ABC):
     def watch_messages(
         self,
         message_filter: Optional[MessageFilter] = None,
+        verify_signatures: bool = False,
     ) -> AsyncIterable[AlephMessage]:
         """
         Iterate over current and future matching messages asynchronously.
 
         :param message_filter: Filter to apply to the messages
+        :param verify_signatures: Whether to verify the signatures of the messages (Default: False)
         """
         raise NotImplementedError("Did you mean to import `AlephHttpClient`?")
 

--- a/src/aleph/sdk/security.py
+++ b/src/aleph/sdk/security.py
@@ -1,0 +1,64 @@
+from importlib import import_module
+from typing import Callable, Dict, Optional, Union
+
+from aleph_message.models import AlephMessage, Chain
+
+from aleph.sdk.chains.common import get_verification_buffer
+from aleph.sdk.query.responses import Post
+
+
+def _try_import_verify_signature(
+    chain: str,
+) -> Optional[
+    Callable[[Union[bytes, str], Union[bytes, str], Union[bytes, str]], None]
+]:
+    """Try to import a chain signature validator."""
+    try:
+        return import_module(f"aleph.sdk.chains.{chain}").verify_signature
+    except (ImportError, AttributeError):
+        return None
+
+
+# This is a dict containing all currently available signature validators,
+# indexed by their Chain abbreviation.
+#
+# Ex.: validators["SOL"] -> aleph.sdk.chains.solana.verify_signature()
+VALIDATORS: Dict[
+    Chain,
+    Optional[Callable[[Union[bytes, str], Union[bytes, str], Union[bytes, str]], None]],
+] = {
+    key: _try_import_verify_signature(value)
+    for key, value in {
+        # TODO: Add AVAX
+        Chain.ETH: "ethereum",
+        Chain.SOL: "sol",
+        Chain.CSDK: "cosmos",
+        Chain.DOT: "substrate",
+        Chain.NULS2: "nuls2",
+        Chain.TEZOS: "tezos",
+    }.items()
+}
+
+
+def verify_message_signature(message: Union[AlephMessage, Post]) -> None:
+    """Verify the signature of a message, raise an error if invalid or unsupported.
+    A BadSignatureError is raised when the signature is incorrect.
+    A ValueError is raised when the chain is not supported or required dependencies are  missing.
+    """
+    if message.chain not in VALIDATORS:
+        raise ValueError(f"Chain {message.chain} is not supported.")
+
+    validator = VALIDATORS[message.chain]
+    if validator is None:
+        raise ValueError(
+            f"Chain {message.chain} is not installed. Install it with `aleph-sdk-python[{message.chain}]`."
+        )
+
+    signature = message.signature
+    public_key = message.sender
+    message = get_verification_buffer(message.dict())
+
+    # to please mypy
+    assert isinstance(signature, (str, bytes))
+
+    validator(signature, public_key, message)

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,0 +1,4 @@
+def test_validators_loaded():
+    import aleph.sdk.security as security
+
+    assert any([validator is not None for validator in security.validators.values()])


### PR DESCRIPTION
EDIT: to be merged after #136 

- Added `security.py` that offers a simple catch-all solution for verifying messages & posts.
- Added `verify_signatures` param to most methods of `AlephClient` to automatically verify signatures, if requested (False by default)
- Added some missing parameters to the `get_posts_iterator` and `get_messages_iterator` functions that were present on their non-iterator cousins.
- Renamed `sol.py` to `solana.py` but still import all of solana.py in sol.py to keep backwards compatibility.
- Renamed `polkadot` extra dependency to `substrate` to align with the module name in `aleph.sdk`.