### PR TITLE
Add file_path param to `download_file()` to directly download files to disk

### DIFF
--- a/src/aleph/sdk/client/abstract.py
+++ b/src/aleph/sdk/client/abstract.py
@@ -103,13 +103,16 @@ class AlephClient(ABC):
     async def download_file(
         self,
         file_hash: str,
-    ) -> bytes:
+        file_path: Optional[Union[Path, str]],
+    ) -> Optional[bytes]:
         """
         Get a file from the storage engine as raw bytes.
 
-        Warning: Downloading large files can be slow and memory intensive.
+        Warning: Downloading large files can be slow and memory intensive. Using the `file_path` parameter is encouraged to prevent storing the file in memory.
 
         :param file_hash: The hash of the file to retrieve.
+        :param file_path: The path to which the file should be saved.
+        :returns: The file's bytes, if no `file_path` is given, otherwise None.
         """
         raise NotImplementedError("Did you mean to import `AlephHttpClient`?")
 

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -1,3 +1,7 @@
+import os.path
+import shutil
+from pathlib import Path
+
 import pytest
 
 from aleph.sdk import AlephHttpClient
@@ -17,6 +21,19 @@ async def test_download(file_hash: str, expected_size: int):
         file_content = await client.download_file(file_hash)  # File is 5B
         file_size = len(file_content)
         assert file_size == expected_size
+
+
+@pytest.mark.asyncio
+async def test_download_to_file():
+    download_path = "./downloads/test.txt"
+    if os.path.exists(download_path):
+        shutil.rmtree(Path(download_path).parent)
+    assert not os.path.exists(download_path)
+    async with AlephHttpClient(api_server=sdk_settings.API_HOST) as client:
+        await client.download_file(
+            "QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH", "./downloads/test.txt"
+        )
+    assert os.path.exists(download_path)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Instead of keeping them in memory. Addresses #37.