### PR TITLE
Fix Hashing for Caching Dependencies in Build Wheel GH Action

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-build-wheels-${{ hashFiles('setup.cfg', 'setup.py') }}
+          key: ${{ runner.os }}-build-wheels-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-build-wheels-
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Build source and wheel packages
         run: |
+          python3 -m pip install .
           python3 -m build
 
       - name: Install the Python wheel

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -50,23 +50,19 @@ jobs:
           sudo apt-get -y upgrade
           sudo apt-get install -y libsecp256k1-dev
 
-      - name: Install required Python packages
+      - name: Install Hatch
         run: |
-          python3 -m pip install --upgrade build
-          python3 -m pip install --user --upgrade twine
+          python3 -m pip install --upgrade hatch
 
       - name: Build source and wheel packages
         run: |
-          python3 -m pip install .
-          python3 -m build
+          python3 -m hatch build
 
       - name: Install the Python wheel
         run: |
           python3 -m pip install dist/aleph_sdk_python-*.whl
 
       - name: Import and use the package
-        # macos tests fail this step because they use Python 3.11, which is not yet supported by our dependencies
-        if: startsWith(matrix.os, 'ubuntu-')
         run: |
           python3 -c "import aleph.sdk"
           python3 -c "from aleph.sdk.chains.ethereum import get_fallback_account; get_fallback_account()"

--- a/README.md
+++ b/README.md
@@ -36,11 +36,10 @@ $ pip install aleph-sdk-python
 Some functionalities require additional dependencies. They can be installed like this:
 
 ```shell
-$ pip install aleph-sdk-python[ethereum, dns]
+$ pip install aleph-sdk-python[solana, dns]
 ```
 
 The following extra dependencies are available:
-- `ethereum` for Ethereum and Ethereum-compatible chains
 - `solana` for Solana accounts and signatures
 - `cosmos` for Substrate/Cosmos accounts and signatures
 - `nuls2` for NULS2 accounts and signatures

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "coincurve; python_version<\"3.11\"",
     "coincurve>=17.0.0; python_version>=\"3.11\"",
     "eth_abi>=4.0.0; python_version>=\"3.11\"",
-    "eth_account>=0.4.0,<0.12.0",
+    "eth_account>=0.4.0,<0.11.0",
     "python-magic",
     "typer",
     "typing_extensions",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "coincurve; python_version<\"3.11\"",
     "coincurve>=17.0.0; python_version>=\"3.11\"",
     "eth_abi>=4.0.0; python_version>=\"3.11\"",
-    "eth_account>=0.4.0",
+    "eth_account>=0.4.0,<0.12.0",
     "python-magic",
     "typer",
     "typing_extensions",
@@ -42,10 +42,6 @@ dns = [
 ]
 docs = [
     "sphinxcontrib-plantuml",
-]
-ethereum = [
-    "eth_abi>=4.0.0; python_version>=\"3.11\"",
-    "eth_account>=0.4.0",
 ]
 ledger = [
     "ledgereth==0.9.0",
@@ -75,7 +71,7 @@ encryption = [
     "eciespy>=0.3.13; python_version>=\"3.11\"",
 ]
 all = [
-    "aleph-sdk-python[cosmos,dns,docs,ethereum,ledger,mqtt,nuls2,polkadot,solana,tezos,encryption]",
+    "aleph-sdk-python[cosmos,dns,docs,ledger,mqtt,nuls2,polkadot,solana,tezos,encryption]",
 ]
 
 [project.urls]
@@ -111,7 +107,6 @@ python = ["3.8", "3.9", "3.10", "3.11"]
 features = [
     "cosmos",
     "dns",
-    "ethereum",
     "ledger",
     "nuls2",
     "polkadot",


### PR DESCRIPTION
Still tried to hash now-nonexistant `setup.cfg` and `setup.py` files to determine hash to lookup cached dependencies.

This causes the latest CI/CD flow on main to fail.