### PR TITLE
Fix: No notification when dependency update breaks

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    # Run every night at 04:00 (GitHub Actions timezone) 
+    # in order to catch when unfrozen dependency updates
+    # break the use of the library.
+    - cron: '4 0 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
Problem: Since the SDK is a library, it should not enforce the
version of the libraries it requires too strictly.

This causes issues when an incompatible dependency upgrade
breaks compatibility without anyone noticing except for the next
CI build.

Solution: Run tests daily with the latest dependencies.
