### PR TITLE
Fix: Could not generate signed messages outside HTTP client

### DIFF
--- a/src/aleph/sdk/utils.py
+++ b/src/aleph/sdk/utils.py
@@ -1,4 +1,5 @@
 import errno
+import hashlib
 import logging
 import os
 from datetime import date, datetime, time
@@ -178,3 +179,8 @@ def parse_volume(volume_dict: Union[Mapping, MachineVolume]) -> MachineVolume:
             continue
     else:
         raise ValueError(f"Could not parse volume: {volume_dict}")
+
+
+def compute_sha256(s: str) -> str:
+    """Compute the SHA256 hash of a string."""
+    return hashlib.sha256(s.encode()).hexdigest()


### PR DESCRIPTION
Problem: Developers could not generate signed messages without using the AlephHttpClient.

Solution: Move and rename the method on the abstract class; Move the utility that generates sha256 hashes to utils.py.
