### PR TITLE
Fix: pkg_resources is obsolete to get package version

### DIFF
--- a/src/aleph/sdk/__init__.py
+++ b/src/aleph/sdk/__init__.py
@@ -1,17 +1,14 @@
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import PackageNotFoundError, version
 
 from aleph.sdk.client import AlephHttpClient, AuthenticatedAlephHttpClient
 
 try:
     # Change here if project is renamed and does not equal the package name
-    dist_name = "aleph-sdk-python"
-    __version__ = get_distribution(dist_name).version
-except DistributionNotFound:
+    __version__ = version("aleph-sdk-python")
+except PackageNotFoundError:
     __version__ = "unknown"
-finally:
-    del get_distribution, DistributionNotFound
 
-__all__ = ["AlephHttpClient", "AuthenticatedAlephHttpClient"]
+__all__ = ["__version__", "AlephHttpClient", "AuthenticatedAlephHttpClient"]
 
 
 def __getattr__(name):


### PR DESCRIPTION
Solution: Use `importlib.metadata.version` instead.
