### PR TITLE
Fix: Pythom 3.12 fails setup libsecp256k1

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,8 +14,11 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11" ]
+        # An issue with secp256k1 prevents Python 3.12 from working
+        # See https://github.com/baking-bad/pytezos/issues/370
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
When "using bundled libsecp256k1", the setup using `/tmp/venv/bin/hatch run testing:test` fails to proceed on Python 3.12.

That library `secp256k1` has been unmaintained for more than 2 years now (0.14.0, Nov 6, 2021), and seems to not support Python 3.12.

The error in the logs:
```
File "/tmp/pip-build-env-ye8d6ort/overlay/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 862, in get_command_obj
 cmd_obj = self.command_obj[command] = klass(self)
                                                ^^^^^^^^^^^
      TypeError: 'NoneType' object is not callable
      [end of output]
```

See failing CI run:
https://github.com/aleph-im/aleph-sdk-python/actions/runs/9613634583/job/26516767722
