### PR TITLE
This branch adds a dockerized environment to reproduce the issues that the CI faced with Ubuntu 24.04 and secp256k1.

### DIFF
--- a/tests/test-ubuntu-24.04-docker.sh
+++ b/tests/test-ubuntu-24.04-docker.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+podman build -t aleph-sdk-ubuntu:24.04 -f tests/ubuntu-24.04.dockerfile .
+podman run -ti --rm -v $(pwd):/mnt aleph-sdk-ubuntu:24.04 bash

--- a/tests/ubuntu-24.04.dockerfile
+++ b/tests/ubuntu-24.04.dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    python3-venv \
+    libsecp256k1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a working virtual environment \
+RUN python3 -m venv /opt/venv
+RUN /opt/venv/bin/python -m pip install --upgrade pip hatch
+
+WORKDIR /mnt
+VOLUME /mnt
+
+# Make it easy to run the tests with the upper arrow
+RUN echo "/opt/venv/bin/hatch run testing:test" >> /root/.bash_history


### PR DESCRIPTION
Usage:
```sh
bash ./tests/test-ubuntu-24.04-docker.sh
```

Then use the upper arrow to run tests with `hatch`.
