### PR TITLE
fix: aiohttp.ClientSession needs to be created inside an async function

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -193,7 +193,7 @@ def mock_session_with_post_success(
     client = AuthenticatedAlephHttpClient(
         account=ethereum_account, api_server="http://localhost"
     )
-    client.http_session = http_session
+    client._http_session = http_session
 
     return client
 
@@ -254,7 +254,7 @@ def make_mock_get_session(
     http_session = MockHttpSession()
 
     client = AlephHttpClient(api_server="http://localhost")
-    client.http_session = http_session
+    client._http_session = http_session
 
     return client
 
@@ -281,6 +281,6 @@ def mock_session_with_rejected_message(
     client = AuthenticatedAlephHttpClient(
         account=ethereum_account, api_server="http://localhost"
     )
-    client.http_session = http_session
+    client._http_session = http_session
 
     return client


### PR DESCRIPTION
This should fix the CI, it used to be a deprecated warning before but this is now an error.

Idk if this changes the way you are supposed to use this class and if it could break the existing API :/
