### PR TITLE
Fix warnings, remove BASE until superfluid upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "aioresponses>=0.7.6",
     "superfluid~=0.2.1",
     "eth_typing==4.3.1",
+    "eth-utils==4.1.1",
     "web3==6.3.0",
 ]
 

--- a/src/aleph/sdk/conf.py
+++ b/src/aleph/sdk/conf.py
@@ -70,6 +70,7 @@ class Settings(BaseSettings):
             rpc="https://base-mainnet.public.blastapi.io",
             token="0xc0Fbc4967259786C743361a5885ef49380473dCF",
             super_token="0xc0Fbc4967259786C743361a5885ef49380473dCF",
+            active=False,
         ),
         Chain.BSC: ChainInfo(
             chain_id=56,


### PR DESCRIPTION
- Fix annoying warnings by defining eth-utils==4.1.1
- Disable BASE chain until superfluid.py repo is updated