### PR TITLE
Fix optional trusted_exec

### DIFF
--- a/src/aleph/sdk/client/authenticated_http.py
+++ b/src/aleph/sdk/client/authenticated_http.py
@@ -540,15 +540,18 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         # Default to the QEMU hypervisor for instances.
         selected_hypervisor: HypervisorType = hypervisor or HypervisorType.qemu
 
+        environment_kwargs = dict(
+            internet=internet,
+            aleph_api=aleph_api,
+            hypervisor=selected_hypervisor,
+        )
+        if trusted_execution:
+            environment_kwargs["trusted_execution"] = trusted_execution
+
         content = InstanceContent(
             address=address,
             allow_amend=allow_amend,
-            environment=InstanceEnvironment(
-                internet=internet,
-                aleph_api=aleph_api,
-                hypervisor=selected_hypervisor,
-                trusted_execution=trusted_execution,
-            ),
+            environment=InstanceEnvironment(**environment_kwargs),
             variables=environment_variables,
             resources=MachineResources(
                 vcpus=vcpus,


### PR DESCRIPTION
Problem: when creating non-coco instances, trusted_execution field is populated
Solution: To not include it

Note: CCN will still put "trusted_execution": null in the final processed message.
