### PR TITLE
Feature: get_message_status and overload of get_message to return status

### DIFF
--- a/src/aleph/sdk/client/http.py
+++ b/src/aleph/sdk/client/http.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os.path
 import ssl
-from aleph_message.status import MessageStatus
 from io import BytesIO
 from pathlib import Path
 from typing import (
@@ -12,15 +11,16 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Tuple,
     Type,
     Union,
     overload,
-    Tuple,
 )
 
 import aiohttp
 from aleph_message import parse_message
 from aleph_message.models import AlephMessage, ItemHash, ItemType
+from aleph_message.status import MessageStatus
 from pydantic import ValidationError
 
 from ..conf import settings


### PR DESCRIPTION
Problem: Currently, there is no method to retrieve the status of a message using its item_hash. This limitation makes it difficult to efficiently check the processing state of specific messages.

Solution: I have added a new method, get_message_status, which allows users to obtain the status of a message by providing the item_hash. I have updated the get_message method to optionally return the status of a message when requested, improving overall flexibility and functionality.

