### PR TITLE
Fix: dependencies were pinned too strictly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ dependencies = [
     "typing_extensions",
     "aioresponses>=0.7.6",
     "aleph-superfluid>=0.2.1",
-    "eth_typing==4.3.1",
-    "web3==6.3.0",
+    "eth_typing>=4.0.0",
+    "web3>=6.3.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This prevented installing the SDK on some systems
such as Nix 24.05.