### PR TITLE
feat(linting): add pydantic to allow mypy to do better testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,9 @@ dependencies = [
     "mypy-extensions==1.0.0",
     "ruff==0.4.8",
     "isort==5.13.2",
+
+    # for more mypy tests
+    "pydantic==1.10.18",
 ]
 [tool.hatch.envs.linting.scripts]
 typing = "mypy --config-file=pyproject.toml {args:} ./src/ ./tests/ ./examples/"


### PR DESCRIPTION
I've discovered while adding yamlfix that does pull pydantic on #172 that
adding it actually allows mypy to test more things.

Turns out those "more things" are actually type errors in our code.

This WIP PR is here to fix those.
