### PR TITLE
Implement GPU support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,15 +30,15 @@ dynamic = [ "version" ]
 dependencies = [
   "aiohttp>=3.8.3",
   "aioresponses>=0.7.6",
-  "aleph-message>=0.5",
+  "aleph-message @ git+https://github.com/aleph-im/aleph-message@andres-feature-add_gpu_requirement",
   "aleph-superfluid>=0.2.1",
-  "base58==2.1.1",                         # Needed now as default with _load_account changement
+  "base58==2.1.1",                                                                                    # Needed now as default with _load_account changement
   "coincurve; python_version<'3.11'",
   "coincurve>=19; python_version>='3.11'",
   "eth-abi>=4; python_version>='3.11'",
   "eth-typing==4.3.1",
   "jwcrypto==1.5.6",
-  "pynacl==1.5",                           # Needed now as default with _load_account changement
+  "pynacl==1.5",                                                                                      # Needed now as default with _load_account changement
   "python-magic",
   "typing-extensions",
   "web3==6.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,15 +30,15 @@ dynamic = [ "version" ]
 dependencies = [
   "aiohttp>=3.8.3",
   "aioresponses>=0.7.6",
-  "aleph-message @ git+https://github.com/aleph-im/aleph-message@andres-feature-add_gpu_requirement",
+  "aleph-message>=0.6",
   "aleph-superfluid>=0.2.1",
-  "base58==2.1.1",                                                                                    # Needed now as default with _load_account changement
+  "base58==2.1.1",                         # Needed now as default with _load_account changement
   "coincurve; python_version<'3.11'",
   "coincurve>=19; python_version>='3.11'",
   "eth-abi>=4; python_version>='3.11'",
   "eth-typing==4.3.1",
   "jwcrypto==1.5.6",
-  "pynacl==1.5",                                                                                      # Needed now as default with _load_account changement
+  "pynacl==1.5",                           # Needed now as default with _load_account changement
   "python-magic",
   "typing-extensions",
   "web3==6.3",


### PR DESCRIPTION
Problem: If a user wants to deploy a VM using the GPU support, he cannot do it from the SDK because it's not updated with latest aleph_message protocol.

Solution: Update aleph_message protocol with last changes.