### PR TITLE
Fix: Remove references to slow server api1.aleph.im

### DIFF
--- a/tests/integration/config.py
+++ b/tests/integration/config.py
@@ -1,3 +1,3 @@
-TARGET_NODE = "https://api1.aleph.im"
+TARGET_NODE = "https://api3.aleph.im"
 REFERENCE_NODE = "https://api2.aleph.im"
 TEST_CHANNEL = "INTEGRATION_TESTS"


### PR DESCRIPTION
Server api1.aleph.im is very slow and outdated
(Core i7 from 2018, up to 40 seconds to respond
to `/metrics` in the monitoring).

We suspect that this causes issues in the
monitoring and performance of the network.

This branch removes all references to api1 and
replaces them with api3 where relevant.
