### PR TITLE
fix: Pydantic v2 errors on unknown env vars

### DIFF
--- a/src/aleph/sdk/conf.py
+++ b/src/aleph/sdk/conf.py
@@ -228,7 +228,7 @@ class Settings(BaseSettings):
     DNS_RESOLVERS: ClassVar[List[str]] = ["9.9.9.9", "1.1.1.1"]
 
     model_config = SettingsConfigDict(
-        env_prefix="ALEPH_", case_sensitive=False, env_file=".env"
+        env_prefix="ALEPH_", case_sensitive=False, env_file=".env", extra="ignore"
     )
 
 


### PR DESCRIPTION
Without the fix, any variable present in a `.env` file where the SDK is used (including the CLI, and products using the CLI, like the [Web3 Hosting GitHub Action](https://github.com/marketplace/actions/aleph-web3-hosting)) throws an error that make it completely unusable:
![image](https://github.com/user-attachments/assets/3d1ceb70-0be0-4ed1-9e54-bdf5c04549b8)


With the fix, it ignores those variables:
<img width="544" alt="image" src="https://github.com/user-attachments/assets/d0ac2c65-b62c-48c8-a897-c36aac54318e" />

This is due to Pydantic v2 being more strict when unexpected fields are given, we have to explicitly ignore them.
