### PR TITLE
Fix:  Client Services Scheduler to handle 404

### DIFF
--- a/src/aleph/sdk/types.py
+++ b/src/aleph/sdk/types.py
@@ -174,7 +174,9 @@ class AllocationItem(BaseModel):
 
 class InstanceWithScheduler(BaseModel):
     source: Literal["scheduler"]
-    allocations: AllocationItem  # Case Scheduler
+    allocations: Optional[
+        AllocationItem
+    ]  # Case Scheduler (None == allocation can't be find on scheduler)
 
 
 class InstanceManual(BaseModel):


### PR DESCRIPTION
The goal of this PR is to handle the case where scheduler send 404 when trying to get allocations of unallocated / wrong instance 

Related ClickUp, GitHub or Jira tickets : ALEPH-597

## Self proofreading checklist
- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.


## Changes
This pull request introduces changes to improve error handling and data type flexibility in the `scheduler` service and related models. The key updates include handling `404` errors gracefully when fetching allocation information and updating type annotations to allow `None` values for allocation-related fields.

### Error handling improvements:

* [`src/aleph/sdk/client/services/scheduler.py`](diffhunk://#diff-00ffbf048adfd22700fe46c8f6cb698b2191f23fd3a6a182780df348c5d7bd0fL43-R58): Updated the `get_allocation` method to handle `404` errors by returning `None` when allocation information cannot be found on the scheduler. Introduced `ClientResponseError` for error handling.

### Data type flexibility:

* [`src/aleph/sdk/types.py`](diffhunk://#diff-35dae2b4eb7a74cd319316827f4bcdbfd0e2267c489e4d5139433e6d250e6c99L177-R179): Modified the `allocations` field in the `InstanceWithScheduler` model to be `Optional[AllocationItem]`, allowing it to represent cases where allocation information is unavailable.

### Typing updates:

* [`src/aleph/sdk/client/services/scheduler.py`](diffhunk://#diff-00ffbf048adfd22700fe46c8f6cb698b2191f23fd3a6a182780df348c5d7bd0fL1-R4): Added `Optional` to type imports to support the updated type annotations.