### PR TITLE
Feature: credits system

### DIFF
--- a/src/aleph/sdk/client/http.py
+++ b/src/aleph/sdk/client/http.py
@@ -49,10 +49,11 @@ from ..exceptions import (
     RemovedMessageError,
     ResourceNotFoundError,
 )
-from ..query.filters import CreditsFilter, MessageFilter, PostFilter
+from ..query.filters import BalanceFilter, MessageFilter, PostFilter
 from ..query.responses import (
     AddressCreditResponse,
-    CreditsResponse,
+    BalanceResponse,
+    CreditsHistoryResponse,
     MessagesResponse,
     Post,
     PostsResponse,
@@ -629,3 +630,17 @@ class AlephHttpClient(AlephClient):
             resp.raise_for_status()
             result = await resp.json()
             return CreditsHistoryResponse.model_validate(result)
+
+    async def get_balances(
+        self,
+        address: str,
+        filter: Optional[BalanceFilter] = None,
+    ) -> BalanceResponse:
+
+        async with self.http_session.get(
+            f"/api/v0/addresses/{address}/balance",
+            params=filter.as_http_params() if filter else None,
+        ) as resp:
+            resp.raise_for_status()
+            result = await resp.json()
+            return BalanceResponse.model_validate(result)

--- a/src/aleph/sdk/client/http.py
+++ b/src/aleph/sdk/client/http.py
@@ -610,27 +610,22 @@ class AlephHttpClient(AlephClient):
             result = await resp.json()
             return AddressCreditResponse.model_validate(result)
 
-    async def get_credits(
+    async def get_credit_history(
         self,
+        address: str,
         page_size: int = 200,
         page: int = 1,
-        credit_filter: Optional[CreditsFilter] = None,
-    ) -> CreditsResponse:
+    ) -> CreditsHistoryResponse:
         """Return List of credits balance for all addresses"""
 
-        if not credit_filter:
-            params = {
-                "page": str(page),
-                "pagination": str(page_size),
-            }
-        else:
-            params = credit_filter.as_http_params()
-            params["page"] = str(page)
-            params["pagination"] = str(page_size)
+        params = {
+            "page": str(page),
+            "pagination": str(page_size),
+        }
 
         async with self.http_session.get(
-            "/api/v0/credit_balances", params=params
+            f"/api/v0/addresses/{address}/credit_history", params=params
         ) as resp:
             resp.raise_for_status()
             result = await resp.json()
-            return CreditsResponse.model_validate(result)
+            return CreditsHistoryResponse.model_validate(result)

--- a/src/aleph/sdk/client/services/instance.py
+++ b/src/aleph/sdk/client/services/instance.py
@@ -77,7 +77,7 @@ class Instance:
             message_filter=MessageFilter(
                 message_types=[MessageType.instance],
                 addresses=[address],
-                message_statuses=[MessageStatus.PROCESSED, MessageStatus.REMOVING]
+                message_statuses=[MessageStatus.PROCESSED, MessageStatus.REMOVING],
             ),
             page_size=100,
         )

--- a/src/aleph/sdk/client/services/instance.py
+++ b/src/aleph/sdk/client/services/instance.py
@@ -77,6 +77,7 @@ class Instance:
             message_filter=MessageFilter(
                 message_types=[MessageType.instance],
                 addresses=[address],
+                message_statuses=[MessageStatus.PROCESSED, MessageStatus.REMOVING]
             ),
             page_size=100,
         )

--- a/src/aleph/sdk/client/services/pricing.py
+++ b/src/aleph/sdk/client/services/pricing.py
@@ -40,6 +40,7 @@ class Price(BaseModel):
     payg: Optional[Decimal] = None
     holding: Optional[Decimal] = None
     fixed: Optional[Decimal] = None
+    credit: Optional[Decimal] = None
 
 
 class ComputeUnit(BaseModel):

--- a/src/aleph/sdk/query/filters.py
+++ b/src/aleph/sdk/query/filters.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, Iterable, Optional, Union
 
-from aleph_message.models import MessageType
+from aleph_message.models import Chain, MessageType
 
 from ..utils import _date_field_to_timestamp, enum_as_str, serialize_list
 
@@ -198,29 +198,25 @@ class PostFilter:
         return result
 
 
-class CreditsFilter:
+class BalanceFilter:
     """
-    A collection of filters that can be applied on Credits queries.
+    A collection of filters that can be applied on Balance queries.
     """
 
-    min_balance: Optional[int]
+    chain: Optional[Chain]
 
     def __init__(
         self,
-        min_balance: Optional[int] = None,
+        chain: Optional[Chain] = None,
     ):
-        self.min_balance = min_balance
+        self.chain = chain
 
     def as_http_params(self) -> Dict[str, str]:
         """Convert the filters into a dict that can be used by an `aiohttp` client
         as `params` to build the HTTP query string.
         """
 
-        partial_result = {
-            "min_balance": (
-                str(self.min_balance) if self.min_balance is not None else None
-            ),
-        }
+        partial_result = {"chain": enum_as_str(self.chain)}
 
         # Ensure all values are strings.
         result: Dict[str, str] = {}

--- a/src/aleph/sdk/query/filters.py
+++ b/src/aleph/sdk/query/filters.py
@@ -56,6 +56,7 @@ class MessageFilter:
     def __init__(
         self,
         message_types: Optional[Iterable[MessageType]] = None,
+        message_statuses: Optional[Iterable[str]] = None,
         content_types: Optional[Iterable[str]] = None,
         content_keys: Optional[Iterable[str]] = None,
         refs: Optional[Iterable[str]] = None,
@@ -82,6 +83,7 @@ class MessageFilter:
         self.end_date = end_date
         self.sort_by = sort_by
         self.sort_order = sort_order
+        self.message_statuses = message_statuses
 
     def as_http_params(self) -> Dict[str, str]:
         """Convert the filters into a dict that can be used by an `aiohttp` client
@@ -95,6 +97,7 @@ class MessageFilter:
                 else None
             ),
             "contentTypes": serialize_list(self.content_types),
+            "message_statuses": serialize_list(self.message_statuses),
             "contentKeys": serialize_list(self.content_keys),
             "refs": serialize_list(self.refs),
             "addresses": serialize_list(self.addresses),

--- a/src/aleph/sdk/query/filters.py
+++ b/src/aleph/sdk/query/filters.py
@@ -193,3 +193,39 @@ class PostFilter:
                 result[key] = value
 
         return result
+
+
+class CreditsFilter:
+    """
+    A collection of filters that can be applied on Credits queries.
+    """
+
+    min_balance: Optional[int]
+
+    def __init__(
+        self,
+        min_balance: Optional[int] = None,
+    ):
+        self.min_balance = min_balance
+
+    def as_http_params(self) -> Dict[str, str]:
+        """Convert the filters into a dict that can be used by an `aiohttp` client
+        as `params` to build the HTTP query string.
+        """
+
+        partial_result = {
+            "min_balance": (
+                str(self.min_balance) if self.min_balance is not None else None
+            ),
+        }
+
+        # Ensure all values are strings.
+        result: Dict[str, str] = {}
+
+        # Drop empty values
+        for key, value in partial_result.items():
+            if value:
+                assert isinstance(value, str), f"Value must be a string: `{value}`"
+                result[key] = value
+
+        return result

--- a/src/aleph/sdk/query/responses.py
+++ b/src/aleph/sdk/query/responses.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import datetime as dt
+from decimal import Decimal
 from typing import Any, Dict, List, Optional, Union
 
 from aleph_message.models import (
@@ -112,4 +114,9 @@ class CreditHistoryResponseItem(BaseModel):
     message_timestamp: dt.datetime
 
 
-
+class BalanceResponse(BaseModel):
+    address: str
+    balance: Decimal
+    details: Optional[Dict[str, Decimal]] = None
+    locked_amount: Decimal
+    credit_balance: int = 0

--- a/src/aleph/sdk/query/responses.py
+++ b/src/aleph/sdk/query/responses.py
@@ -88,8 +88,28 @@ class AddressCreditResponse(BaseModel):
     credits: float
 
 
-class CreditsResponse(PaginationResponse):
+class CreditsHistoryResponse(PaginationResponse):
     """Response from an aleph.im node API on the path /api/v0/credits"""
 
-    credit_balances: List[AddressCreditResponse]
-    pagination_item: str = "credit_balances"
+    address: str
+    credit_balances: List[CreditHistoryResponseItem]
+    pagination_item: str = "credit_history"
+
+
+class CreditHistoryResponseItem(BaseModel):
+    amount: int
+    ratio: Optional[Decimal] = None
+    tx_hash: Optional[str] = None
+    token: Optional[str] = None
+    chain: Optional[str] = None
+    provider: Optional[str] = None
+    origin: Optional[str] = None
+    origin_ref: Optional[str] = None
+    payment_method: Optional[str] = None
+    credit_ref: str
+    credit_index: int
+    expiration_date: Optional[dt.datetime] = None
+    message_timestamp: dt.datetime
+
+
+

--- a/src/aleph/sdk/query/responses.py
+++ b/src/aleph/sdk/query/responses.py
@@ -79,3 +79,17 @@ class PriceResponse(BaseModel):
 
     required_tokens: float
     payment_type: str
+
+
+class AddressCreditResponse(BaseModel):
+    """Response from an aleph.im node API on the path /api/v0/addresses/{address}/credit_balance"""
+
+    address: str
+    credits: float
+
+
+class CreditsResponse(PaginationResponse):
+    """Response from an aleph.im node API on the path /api/v0/credits"""
+
+    credit_balances: List[AddressCreditResponse]
+    pagination_item: str = "credit_balances"

--- a/src/aleph/sdk/types.py
+++ b/src/aleph/sdk/types.py
@@ -119,6 +119,7 @@ class TokenType(str, Enum):
 
     GAS = "GAS"
     ALEPH = "ALEPH"
+    CREDIT = "CREDIT"
 
 
 # Scheduler

--- a/tests/unit/services/pricing_aggregate.json
+++ b/tests/unit/services/pricing_aggregate.json
@@ -6,11 +6,13 @@
         "price": {
           "storage": {
             "payg": "0.000000977",
-            "holding": "0.05"
+            "holding": "0.05",
+            "credit": "0.000000977"
           },
           "compute_unit": {
             "payg": "0.011",
-            "holding": "200"
+            "holding": "200",
+            "credit": "0.011"
           }
         },
         "tiers": [
@@ -48,7 +50,8 @@
       "storage": {
         "price": {
           "storage": {
-            "holding": "0.333333333"
+            "holding": "0.333333333",
+            "credit": "0.333333333"
           }
         }
       },
@@ -56,11 +59,13 @@
         "price": {
           "storage": {
             "payg": "0.000000977",
-            "holding": "0.05"
+            "holding": "0.05",
+            "credit": "0.000000977"
           },
           "compute_unit": {
             "payg": "0.055",
-            "holding": "1000"
+            "holding": "1000",
+            "credit": "0.055"
           }
         },
         "tiers": [
@@ -149,10 +154,12 @@
       "instance_gpu_premium": {
         "price": {
           "storage": {
-            "payg": "0.000000977"
+            "payg": "0.000000977",
+            "credit": "0.000000977"
           },
           "compute_unit": {
-            "payg": "0.56"
+            "payg": "0.56",
+            "credit": "0.56"
           }
         },
         "tiers": [
@@ -179,11 +186,13 @@
         "price": {
           "storage": {
             "payg": "0.000000977",
-            "holding": "0.05"
+            "holding": "0.05",
+            "credit": "0.000000977"
           },
           "compute_unit": {
             "payg": "0.11",
-            "holding": "2000"
+            "holding": "2000",
+            "credit": "0.11"
           }
         },
         "tiers": [
@@ -221,10 +230,12 @@
       "instance_gpu_standard": {
         "price": {
           "storage": {
-            "payg": "0.000000977"
+            "payg": "0.000000977",
+            "credit": "0.000000977"
           },
           "compute_unit": {
-            "payg": "0.28"
+            "payg": "0.28",
+            "credit": "0.28"
           }
         },
         "tiers": [

--- a/tests/unit/services/pricing_aggregate.json
+++ b/tests/unit/services/pricing_aggregate.json
@@ -112,11 +112,13 @@
         "price": {
           "storage": {
             "payg": "0.000000977",
-            "holding": "0.05"
+            "holding": "0.05",
+            "credit": "0.000000977"
           },
           "compute_unit": {
             "payg": "0.055",
-            "holding": "1000"
+            "holding": "1000",
+            "credit": "0.055"
           }
         },
         "tiers": [

--- a/tests/unit/test_balance.py
+++ b/tests/unit/test_balance.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+
+import pytest
+
+from aleph.sdk.query.responses import BalanceResponse
+from tests.unit.conftest import make_mock_get_session
+
+
+@pytest.mark.asyncio
+async def test_get_balances():
+    """
+    Test that the get_balances method returns the correct BalanceResponse
+    for a specific address when called on the AlephHttpClient.
+    """
+    address = "0xd463495a6FEaC9921FD0C3a595B81E7B2C02B24d"
+
+    balance_data = {
+        "address": address,
+        "balance": 351.25,
+        "details": {"ETH": 100.5, "SOL": 250.75},
+        "locked_amount": 50.0,
+        "credit_balance": 1000,
+    }
+
+    mock_client = make_mock_get_session(balance_data)
+
+    expected_url = f"/api/v0/addresses/{address}/balance"
+    # Adding type assertion to handle None case
+    assert mock_client._http_session is not None
+    with patch.object(
+        mock_client._http_session, "get", wraps=mock_client._http_session.get
+    ) as spy:
+        async with mock_client:
+            response = await mock_client.get_balances(address)
+
+            # Verify the response
+            assert isinstance(response, BalanceResponse)
+            # Verify the balances command calls the correct URL
+            spy.assert_called_once_with(expected_url, params=None)

--- a/tests/unit/test_credits.py
+++ b/tests/unit/test_credits.py
@@ -1,0 +1,83 @@
+import pytest
+
+from aleph.sdk.query.responses import AddressCreditResponse, CreditsResponse
+from tests.unit.conftest import make_mock_get_session
+
+
+@pytest.mark.asyncio
+async def test_get_credits():
+    """
+    Test that the get_credits method returns the correct CreditsResponse
+    when called on the AlephHttpClient.
+    """
+    # Mock data from the example
+    credits_data = {
+        "credit_balances": [
+            {
+                "address": "0xd463495a6FEaC9921FD0C3a595B81E7B2C02B57d",
+                "credits": 100000,
+            },
+            {
+                "address": "0x28152dDF5cd213F341c8104d5361bBe41e95b301",
+                "credits": 1000000,
+            },
+        ],
+        "pagination_per_page": 100,
+        "pagination_page": 1,
+        "pagination_total": 0,
+        "pagination_item": "credit_balances",
+    }
+
+    # Create mock client with the predefined response
+    mock_client = make_mock_get_session(credits_data)
+
+    # Test the method
+    async with mock_client:
+        response = await mock_client.get_credits()
+
+        # Verify the response structure
+        assert isinstance(response, CreditsResponse)
+        assert response.pagination_page == 1
+        assert response.pagination_per_page == 100
+        assert response.pagination_item == "credit_balances"
+
+        # Verify the credit balances
+        assert len(response.credit_balances) == 2
+
+        # Check first credit balance
+        first_balance = response.credit_balances[0]
+        assert isinstance(first_balance, AddressCreditResponse)
+        assert first_balance.address == "0xd463495a6FEaC9921FD0C3a595B81E7B2C02B57d"
+        assert first_balance.credits == 100000
+
+        # Check second credit balance
+        second_balance = response.credit_balances[1]
+        assert isinstance(second_balance, AddressCreditResponse)
+        assert second_balance.address == "0x28152dDF5cd213F341c8104d5361bBe41e95b301"
+        assert second_balance.credits == 1000000
+
+
+@pytest.mark.asyncio
+async def test_get_credit_balance():
+    """
+    Test that the get_credit_balance method returns the correct AddressCreditResponse
+    for a specific address when called on the AlephHttpClient.
+    """
+    # Mock data from the example
+    credit_balance_data = {
+        "address": "0xd463495a6FEaC9921FD0C3a595B81E7B2C02B57d",
+        "credits": 100000,
+    }
+
+    # Create mock client with the predefined response
+    mock_client = make_mock_get_session(credit_balance_data)
+
+    # Test the method with a specific address
+    address = "0xd463495a6FEaC9921FD0C3a595B81E7B2C02B57d"
+    async with mock_client:
+        response = await mock_client.get_credit_balance(address)
+
+        # Verify the response
+        assert isinstance(response, AddressCreditResponse)
+        assert response.address == address
+        assert response.credits == 100000


### PR DESCRIPTION
This Pr adds add : 
- Credits field on Price to handle credits on pricing aggregate
- New method on `AlephHttpClient` : `get_credit_balance` and `get_credits`

Related ClickUp, GitHub or Jira tickets : ALEPH-620

## Self proofreading checklist

- [x] The new code clear, easy to read and well commented.
- [x] New code does not duplicate the functions of builtin or popular libraries.
- [x] An LLM was used to review the new code and look for simplifications.
- [x] New classes and functions contain docstrings explaining what they provide.
- [x] All new code is covered by relevant tests.


## Changes
This pull request adds comprehensive support for querying and handling credit balances in the Aleph SDK. It introduces new API methods to retrieve credit balances for individual addresses and for all addresses, adds corresponding filter and response classes, and updates the pricing schema to include credit-based pricing. Additionally, new unit tests ensure the correctness of these features.

**Credit balance API and query support:**

* Added `get_credit_balance` and `get_credits` async methods to `AlephHttpClient` for fetching credit balances for a specific address and for all addresses, respectively.
* Introduced the `CreditsFilter` class for filtering credit queries by minimum balance, with HTTP parameter serialization.
* Added response models `AddressCreditResponse` and `CreditsResponse` to represent credit balance data returned from the API.

**Pricing schema updates:**

* Updated the `Price` model in `pricing.py` and the pricing data in `pricing_aggregate.json` to include the new `credit` field, enabling credit-based pricing for storage and compute units. [[1]](diffhunk://#diff-a1fd5545daf0a1d4414b75447228b312d9a3addd4d6eaf84fe300a9bd34c5ba4R43) [[2]](diffhunk://#diff-028b0311427a7da024ab86181d0d8d72e5bf8c08330ab16d30b3692c58ad6cbaL9-R15) [[3]](diffhunk://#diff-028b0311427a7da024ab86181d0d8d72e5bf8c08330ab16d30b3692c58ad6cbaL51-R68) [[4]](diffhunk://#diff-028b0311427a7da024ab86181d0d8d72e5bf8c08330ab16d30b3692c58ad6cbaL152-R162) [[5]](diffhunk://#diff-028b0311427a7da024ab86181d0d8d72e5bf8c08330ab16d30b3692c58ad6cbaL182-R195) [[6]](diffhunk://#diff-028b0311427a7da024ab86181d0d8d72e5bf8c08330ab16d30b3692c58ad6cbaL224-R238)

**Testing:**

* Added unit tests in `test_credits.py` to verify the correct behavior of credit balance retrieval methods and response parsing.

## Notes
For testing use : http://51.159.106.166:4024/
exemple usage :
```
import asyncio

from aleph.sdk.client import AlephHttpClient
from aleph.sdk.chains.ethereum import get_fallback_account
from aleph.sdk.query.filters import CreditsFilter

async def main():
    async with AlephHttpClient(api_server="http://51.159.106.166:4024/") as client:
        credit_balance = await client.get_credit_balance('0xd463495a6FEaC9921FD0C3a595B81E7B2C02B57d')
        print("Credit : Balance:", credit_balance)
        filter = CreditsFilter(min_balance=100000)
        full_credit_info = await client.get_credits(credit_filter=filter)
        print("Credit : Full info:", full_credit_info)
        
asyncio.run(main())
```

