### PR TITLE
Feature: allow to update CRN_LIST_URL from .env

### DIFF
--- a/src/aleph/sdk/conf.py
+++ b/src/aleph/sdk/conf.py
@@ -86,7 +86,7 @@ class Settings(BaseSettings):
 
     DNS_API: ClassVar[str] = "https://api.dns.public.aleph.sh/instances/list"
     CRN_URL_UPDATE: ClassVar[str] = "{crn_url}/control/machine/{vm_hash}/update"
-    CRN_LIST_URL: ClassVar[str] = "https://crns-list.aleph.sh/crns.json"
+    CRN_LIST_URL: str = "https://crns-list.aleph.sh/crns.json"
     CRN_VERSION_URL: ClassVar[str] = (
         "https://api.github.com/repos/aleph-im/aleph-vm/releases/latest"
     )


### PR DESCRIPTION
On CLI side we want to be able to run a fake crn_list api to be able to create instance / interact with a crn not listed in the crn_list.

The issue is having 
CRN_LIST_URL as a ClassVar don't allow to update using .env