### PR TITLE
Fix: filter on crn list & port-forwarding 

### DIFF
--- a/src/aleph/sdk/client/http.py
+++ b/src/aleph/sdk/client/http.py
@@ -3,6 +3,7 @@ import logging
 import os.path
 import ssl
 import time
+from decimal import Decimal
 from io import BytesIO
 from pathlib import Path
 from typing import (
@@ -543,8 +544,16 @@ class AlephHttpClient(AlephClient):
             try:
                 resp.raise_for_status()
                 response_json = await resp.json()
+                token_value = response_json.get(
+                    "cost", response_json.get("required_tokens")
+                )
+                if isinstance(token_value, str):
+                    required_tokens = Decimal(token_value)
+                else:
+                    required_tokens = Decimal(str(token_value))
+
                 return PriceResponse(
-                    required_tokens=response_json["required_tokens"],
+                    required_tokens=required_tokens,
                     payment_type=response_json["payment_type"],
                 )
             except aiohttp.ClientResponseError as e:

--- a/src/aleph/sdk/client/http.py
+++ b/src/aleph/sdk/client/http.py
@@ -3,7 +3,6 @@ import logging
 import os.path
 import ssl
 import time
-from decimal import Decimal
 from io import BytesIO
 from pathlib import Path
 from typing import (
@@ -532,7 +531,10 @@ class AlephHttpClient(AlephClient):
             try:
                 resp.raise_for_status()
                 response_json = await resp.json()
+                cost = response_json.get("cost", None)
+
                 return PriceResponse(
+                    cost=cost,
                     required_tokens=response_json["required_tokens"],
                     payment_type=response_json["payment_type"],
                 )
@@ -544,16 +546,12 @@ class AlephHttpClient(AlephClient):
             try:
                 resp.raise_for_status()
                 response_json = await resp.json()
-                token_value = response_json.get(
-                    "cost", response_json.get("required_tokens")
-                )
-                if isinstance(token_value, str):
-                    required_tokens = Decimal(token_value)
-                else:
-                    required_tokens = Decimal(str(token_value))
+                cost = response_json.get("cost", None)
+                required_tokens = response_json["required_tokens"]
 
                 return PriceResponse(
                     required_tokens=required_tokens,
+                    cost=cost,
                     payment_type=response_json["payment_type"],
                 )
             except aiohttp.ClientResponseError as e:

--- a/src/aleph/sdk/client/services/crn.py
+++ b/src/aleph/sdk/client/services/crn.py
@@ -230,9 +230,8 @@ class Crn:
         dict
             The parsed JSON response from /crns.json.
         """
-        # We want filter_inactive = (not only_active)
         # Convert bool to string for the query parameter
-        filter_inactive_str = str(not only_active).lower()
+        filter_inactive_str = str(only_active).lower()
         params = {"filter_inactive": filter_inactive_str}
 
         # Create a new session for external domain requests

--- a/src/aleph/sdk/query/responses.py
+++ b/src/aleph/sdk/query/responses.py
@@ -79,7 +79,7 @@ class MessagesResponse(PaginationResponse):
 class PriceResponse(BaseModel):
     """Response from an aleph.im node API on the path /api/v0/price/{item_hash}"""
 
-    required_tokens: float
+    required_tokens: Decimal
     payment_type: str
 
 

--- a/src/aleph/sdk/query/responses.py
+++ b/src/aleph/sdk/query/responses.py
@@ -80,6 +80,7 @@ class PriceResponse(BaseModel):
     """Response from an aleph.im node API on the path /api/v0/price/{item_hash}"""
 
     required_tokens: Decimal
+    cost: Optional[str] = None
     payment_type: str
 
 

--- a/src/aleph/sdk/types.py
+++ b/src/aleph/sdk/types.py
@@ -309,7 +309,7 @@ class Ports(BaseModel):
     ports: Dict[int, PortFlags]
 
 
-AllForwarders = RootModel[Dict[ItemHash, Ports]]
+AllForwarders = RootModel[Dict[ItemHash, Optional[Ports]]]
 
 
 class DictLikeModel(BaseModel):

--- a/tests/unit/test_price.py
+++ b/tests/unit/test_price.py
@@ -46,7 +46,8 @@ async def test_get_program_price_cost_and_required_token():
 
     # Expected model using the cost field as the source of truth
     expected_model = PriceResponse(
-        required_tokens=Decimal("0.001527777777777777"),
+        required_tokens=Decimal("0.001527777777777778"),
+        cost=expected["cost"],
         payment_type=expected["payment_type"],
     )
 
@@ -61,11 +62,15 @@ async def test_get_program_price_cost_and_required_token():
 
     async with mock_session:
         response = await mock_session.get_program_price("cacacacacacaca")
-        assert response == expected_model
+        assert str(response.required_tokens) == str(expected_model.required_tokens)
+        assert response.cost == expected_model.cost
+        assert response.payment_type == expected_model.payment_type
 
     async with mock_session_old:
         response = await mock_session_old.get_program_price("cacacacacacaca")
-        assert response == expected_model_old
+        assert str(response.required_tokens) == str(expected_model_old.required_tokens)
+        assert response.cost == expected_model_old.cost
+        assert response.payment_type == expected_model_old.payment_type
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_price.py
+++ b/tests/unit/test_price.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pytest
 
 from aleph.sdk.exceptions import InvalidHashError
@@ -19,6 +21,51 @@ async def test_get_program_price_valid():
     async with mock_session:
         response = await mock_session.get_program_price("cacacacacacaca")
         assert response == expected
+
+
+@pytest.mark.asyncio
+async def test_get_program_price_cost_and_required_token():
+    """
+    Test that the get_program_price method returns the correct PriceResponse
+    when
+        1 ) cost & required_token is here (priority to cost) who is a string that convert to decimal
+        2 ) When only required_token is here who is a float that now would be to be convert to decimal
+    """
+    # Case 1
+    expected = {
+        "required_tokens": 0.001527777777777778,
+        "cost": "0.001527777777777777",
+        "payment_type": "credit",
+    }
+
+    # Case 2
+    expected_old = {
+        "required_tokens": 0.001527777777777778,
+        "payment_type": "credit",
+    }
+
+    # Expected model using the cost field as the source of truth
+    expected_model = PriceResponse(
+        required_tokens=Decimal("0.001527777777777777"),
+        payment_type=expected["payment_type"],
+    )
+
+    # Expected model for the old format
+    expected_model_old = PriceResponse(
+        required_tokens=Decimal(str(expected_old["required_tokens"])),
+        payment_type=expected_old["payment_type"],
+    )
+
+    mock_session = make_mock_get_session(expected)
+    mock_session_old = make_mock_get_session(expected_old)
+
+    async with mock_session:
+        response = await mock_session.get_program_price("cacacacacacaca")
+        assert response == expected_model
+
+    async with mock_session_old:
+        response = await mock_session_old.get_program_price("cacacacacacaca")
+        assert response == expected_model_old
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
fix: https://github.com/aleph-im/aleph-sdk-python/pull/236

and fix an issue where crn wouldn't get fetch on the crn list due to filter

Also include the fix from this other PR spotted by @RezaRahemtola (https://github.com/aleph-im/aleph-sdk-python/pull/236):

When deleting an instance, the behavior for the `ports-forwarding` aggregate is different between the CLI and the UI:
- The CLI will update the aggregate to keep the value of the item hash to the existing values (example: https://explorer.aleph.cloud/address/ETH/0x238224C744F4b90b4494516e074D2676ECfC6803/message/AGGREGATE/4acb1fac2b28a54c73160c1cdde93c51bb4712be10ca34f934b209b832b2ebbb). This may be an unwanted behavior to investigate, but it is not the scope of this tentative fix.
- The UI will update the aggregate to set the value of the item hash to `null` (example: https://explorer.aleph.cloud/address/ETH/0x238224C744F4b90b4494516e074D2676ECfC6803/message/AGGREGATE/6bc45c2746f289e8fcf12fd44a0b41eae4c57ba408174cfaa63dda3ca002e2bb)

The problem is that the types in the SDK (and thus in the CLI) don't expect an item hash in the `ports-forwarding` aggregate to be null (as you can see, I just added the possibility in this PR).

This means that if a user deletes an instance in the UI, then the CLI won't function properly anymore, as it will throw Pydantic parsing errors when fetching the ports, for example when deleting an instance:
<img width="1782" height="294" alt="image" src="https://github.com/user-attachments/assets/bdfc02c1-43a7-4e2e-80e8-a52d6f7f0f9f" />

Unfortunately the fix is probably not as simple as adding this line:
- Adding the possibility of null ports may (well is according to the tests) break some stuff in the SDK / CLI so it should be done carefully
- Updating the UI to avoid setting null values is also out of the question imo, as it won't solve the issue for existing users (and after a quick look at the UI, it's using a generic part of the code to delete the ports so it would need a bit more than a single line change too)