### PR TITLE
Small improvements to scripts/build-to-publish.sh

### DIFF
--- a/scripts/build-to-publish.sh
+++ b/scripts/build-to-publish.sh
@@ -1,21 +1,30 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -euf
+set -euo pipefail
 
-# Use Podman if installed, else use Docker
-if hash podman 2> /dev/null
-then
-  DOCKER_COMMAND=podman
-else
-  DOCKER_COMMAND=docker
+# Allow overriding with env DOCKER_COMMAND, else prefer podman if available, fallback to docker
+DOCKER_COMMAND=${DOCKER_COMMAND:-}
+if [ -z "$DOCKER_COMMAND" ]; then
+  if command -v podman >/dev/null 2>&1; then
+    DOCKER_COMMAND=podman
+  else
+    DOCKER_COMMAND=docker
+  fi
 fi
 
 mkdir -p ./dist
-chmod 0777 ./dist
+chmod 0755 ./dist
 
-$DOCKER_COMMAND build -t aleph-sdk-python -f docker/python-3.9.dockerfile .
+# Build image (use --pull for freshest base)
+$DOCKER_COMMAND build --pull -t aleph-sdk-python -f docker/python-3.9.dockerfile .
+
+# Run container interactively; map dist and run as current user to avoid root-owned files
+USER_UID=$(id -u)
+USER_GID=$(id -g)
+
 $DOCKER_COMMAND run -ti --rm \
   -w /opt/aleph-sdk-python \
   -v "$(pwd)/dist":/opt/aleph-sdk-python/dist \
+  -u "${USER_UID}:${USER_GID}" \
   --entrypoint /bin/bash \
   aleph-sdk-python


### PR DESCRIPTION
Summary
Make minimal, safe improvements to the build-to-publish.sh script:
- Respect DOCKER_COMMAND env var and prefer podman when available.
- Ensure strict bash flags (set -euo pipefail).
- Create ./dist with safe permissions.
- Use --pull when building to get freshest base image.
- Run the container as the invoking user's UID:GID to avoid root-owned files.

Changes
- scripts/build-to-publish.sh: add env override for DOCKER_COMMAND, prefer podman, tighten bash flags, ensure dist dir, add --pull to docker build, pass UID:GID to docker/podman run.

Rationale
These are small, backward-compatible changes that reduce surprises (tool selection), ensure predictable failures, avoid file permission issues on the host, and get up-to-date base images.
