### PR TITLE
Feature: Implement missing PyAleph API endpoints

### DIFF
--- a/src/aleph/sdk/client/http.py
+++ b/src/aleph/sdk/client/http.py
@@ -963,10 +963,18 @@ class AlephHttpClient(AlephClient):
         :param page: Page number starting at 1
         :param filter: Query parameters for filtering and sorting
         :return: Account files response with pagination
-        :raises ValueError: If the address contains path separators or traversal characters
+        :raises ValueError: If the address is empty, whitespace-only, or contains
+            path separators or traversal characters
         :raises aiohttp.ClientResponseError: If the address has no files (HTTP 404)
         """
-        if "/" in address or "\\" in address or ".." in address:
+        if not address or not address.strip():
+            raise ValueError("address must not be empty or whitespace")
+        if (
+            "/" in address
+            or "\\" in address
+            or ".." in address
+            or address.startswith("./")
+        ):
             raise ValueError(f"Invalid address: {address!r}")
 
         params = self._paginated_params(page, page_size, filter)

--- a/src/aleph/sdk/client/http.py
+++ b/src/aleph/sdk/client/http.py
@@ -53,8 +53,15 @@ from ..exceptions import (
     RemovedMessageError,
     ResourceNotFoundError,
 )
-from ..query.filters import BalanceFilter, MessageFilter, PostFilter, SortBy
+from ..query.filters import (
+    AddressesFilter,
+    BalanceFilter,
+    MessageFilter,
+    PostFilter,
+    SortBy,
+)
 from ..query.responses import (
+    AddressStatsResponse,
     AggregatesResponse,
     BalanceResponse,
     CreditsHistoryResponse,
@@ -880,3 +887,34 @@ class AlephHttpClient(AlephClient):
             resp.raise_for_status()
             result = await resp.json()
             return BalanceResponse.model_validate(result)
+
+    async def get_address_stats(
+        self,
+        page_size: int = 200,
+        page: int = 1,
+        filter: Optional[AddressesFilter] = None,
+    ) -> AddressStatsResponse:
+        """
+        Get address statistics with optional filtering and sorting.
+
+        :param page_size: Number of results per page
+        :param page: Page number starting at 1
+        :param filter: Query parameters for filtering and sorting
+        :return: Address statistics response with pagination
+        """
+        if not filter:
+            params = {
+                "page": str(page),
+                "pagination": str(page_size),
+            }
+        else:
+            params = filter.as_http_params()
+            params["page"] = str(page)
+            params["pagination"] = str(page_size)
+
+        async with self.http_session.get(
+            "/api/v1/addresses/stats.json", params=params
+        ) as resp:
+            resp.raise_for_status()
+            result = await resp.json()
+            return AddressStatsResponse.model_validate(result)

--- a/src/aleph/sdk/client/http.py
+++ b/src/aleph/sdk/client/http.py
@@ -60,6 +60,7 @@ from ..query.filters import (
 >>>>>>> ceda020 (feature: new method in AlephHttpClient `get_account_files`)
     AddressesFilter,
     BalanceFilter,
+    ChainBalancesFilter,
     MessageFilter,
     PostFilter,
 <<<<<<< HEAD
@@ -72,6 +73,7 @@ from ..query.responses import (
     AddressStatsResponse,
     AggregatesResponse,
     BalanceResponse,
+    ChainBalancesResponse,
     CreditsHistoryResponse,
     CursorMessagesResponse,
     CursorPostsResponse,
@@ -895,6 +897,35 @@ class AlephHttpClient(AlephClient):
             resp.raise_for_status()
             result = await resp.json()
             return BalanceResponse.model_validate(result)
+
+    async def get_chain_balances(
+        self,
+        page_size: int = 100,
+        page: int = 1,
+        filter: Optional[ChainBalancesFilter] = None,
+    ) -> ChainBalancesResponse:
+        """
+        Get balances across multiple addresses and chains.
+
+        :param page_size: Number of results per page (default 100)
+        :param page: Page number starting at 1
+        :param filter: Query parameters for filtering by chains and minimum balance
+        :return: Chain balances response with pagination
+        """
+        if not filter:
+            params = {
+                "page": str(page),
+                "pagination": str(page_size),
+            }
+        else:
+            params = filter.as_http_params()
+            params["page"] = str(page)
+            params["pagination"] = str(page_size)
+
+        async with self.http_session.get("/api/v0/balances", params=params) as resp:
+            resp.raise_for_status()
+            result = await resp.json()
+            return ChainBalancesResponse.model_validate(result)
 
     async def get_address_stats(
         self,

--- a/src/aleph/sdk/client/http.py
+++ b/src/aleph/sdk/client/http.py
@@ -54,13 +54,21 @@ from ..exceptions import (
     ResourceNotFoundError,
 )
 from ..query.filters import (
+<<<<<<< HEAD
+=======
+    AccountFilesFilter,
+>>>>>>> ceda020 (feature: new method in AlephHttpClient `get_account_files`)
     AddressesFilter,
     BalanceFilter,
     MessageFilter,
     PostFilter,
+<<<<<<< HEAD
     SortBy,
+=======
+>>>>>>> ceda020 (feature: new method in AlephHttpClient `get_account_files`)
 )
 from ..query.responses import (
+    AccountFilesResponse,
     AddressStatsResponse,
     AggregatesResponse,
     BalanceResponse,
@@ -918,3 +926,37 @@ class AlephHttpClient(AlephClient):
             resp.raise_for_status()
             result = await resp.json()
             return AddressStatsResponse.model_validate(result)
+
+    async def get_account_files(
+        self,
+        address: str,
+        page_size: int = 100,
+        page: int = 1,
+        filter: Optional[AccountFilesFilter] = None,
+    ) -> AccountFilesResponse:
+        """
+        Get files stored by a specific address.
+
+        :param address: The account address to query files for
+        :param page_size: Number of results per page (default 100)
+        :param page: Page number starting at 1
+        :param filter: Query parameters for filtering and sorting
+        :return: Account files response with pagination
+        :raises aiohttp.ClientResponseError: If the address has no files (HTTP 404)
+        """
+        if not filter:
+            params = {
+                "page": str(page),
+                "pagination": str(page_size),
+            }
+        else:
+            params = filter.as_http_params()
+            params["page"] = str(page)
+            params["pagination"] = str(page_size)
+
+        async with self.http_session.get(
+            f"/api/v0/addresses/{address}/files", params=params
+        ) as resp:
+            resp.raise_for_status()
+            result = await resp.json()
+            return AccountFilesResponse.model_validate(result)

--- a/src/aleph/sdk/client/http.py
+++ b/src/aleph/sdk/client/http.py
@@ -54,19 +54,13 @@ from ..exceptions import (
     ResourceNotFoundError,
 )
 from ..query.filters import (
-<<<<<<< HEAD
-=======
     AccountFilesFilter,
->>>>>>> ceda020 (feature: new method in AlephHttpClient `get_account_files`)
     AddressesFilter,
     BalanceFilter,
     ChainBalancesFilter,
     MessageFilter,
     PostFilter,
-<<<<<<< HEAD
     SortBy,
-=======
->>>>>>> ceda020 (feature: new method in AlephHttpClient `get_account_files`)
 )
 from ..query.responses import (
     AccountFilesResponse,
@@ -898,6 +892,18 @@ class AlephHttpClient(AlephClient):
             result = await resp.json()
             return BalanceResponse.model_validate(result)
 
+    @staticmethod
+    def _paginated_params(
+        page: int,
+        page_size: int,
+        filter: Optional[Any] = None,
+    ) -> Dict[str, str]:
+        """Build query params dict combining filter params and pagination."""
+        params = filter.as_http_params() if filter else {}
+        params["page"] = str(page)
+        params["pagination"] = str(page_size)
+        return params
+
     async def get_chain_balances(
         self,
         page_size: int = 100,
@@ -912,15 +918,7 @@ class AlephHttpClient(AlephClient):
         :param filter: Query parameters for filtering by chains and minimum balance
         :return: Chain balances response with pagination
         """
-        if not filter:
-            params = {
-                "page": str(page),
-                "pagination": str(page_size),
-            }
-        else:
-            params = filter.as_http_params()
-            params["page"] = str(page)
-            params["pagination"] = str(page_size)
+        params = self._paginated_params(page, page_size, filter)
 
         async with self.http_session.get("/api/v0/balances", params=params) as resp:
             resp.raise_for_status()
@@ -929,27 +927,19 @@ class AlephHttpClient(AlephClient):
 
     async def get_address_stats(
         self,
-        page_size: int = 200,
+        page_size: int = 100,
         page: int = 1,
         filter: Optional[AddressesFilter] = None,
     ) -> AddressStatsResponse:
         """
         Get address statistics with optional filtering and sorting.
 
-        :param page_size: Number of results per page
+        :param page_size: Number of results per page (default 100)
         :param page: Page number starting at 1
         :param filter: Query parameters for filtering and sorting
         :return: Address statistics response with pagination
         """
-        if not filter:
-            params = {
-                "page": str(page),
-                "pagination": str(page_size),
-            }
-        else:
-            params = filter.as_http_params()
-            params["page"] = str(page)
-            params["pagination"] = str(page_size)
+        params = self._paginated_params(page, page_size, filter)
 
         async with self.http_session.get(
             "/api/v1/addresses/stats.json", params=params
@@ -973,17 +963,13 @@ class AlephHttpClient(AlephClient):
         :param page: Page number starting at 1
         :param filter: Query parameters for filtering and sorting
         :return: Account files response with pagination
+        :raises ValueError: If the address contains path separators or traversal characters
         :raises aiohttp.ClientResponseError: If the address has no files (HTTP 404)
         """
-        if not filter:
-            params = {
-                "page": str(page),
-                "pagination": str(page_size),
-            }
-        else:
-            params = filter.as_http_params()
-            params["page"] = str(page)
-            params["pagination"] = str(page_size)
+        if "/" in address or "\\" in address or ".." in address:
+            raise ValueError(f"Invalid address: {address!r}")
+
+        params = self._paginated_params(page, page_size, filter)
 
         async with self.http_session.get(
             f"/api/v0/addresses/{address}/files", params=params

--- a/src/aleph/sdk/query/filters.py
+++ b/src/aleph/sdk/query/filters.py
@@ -329,3 +329,48 @@ class AccountFilesFilter:
                 result[key] = value
 
         return result
+
+
+class ChainBalancesFilter:
+    """
+    A collection of query parameters for chain balances queries.
+
+    :param chains: Filter by specific blockchain chains
+    :param min_balance: Minimum balance required (must be >= 1)
+    """
+
+    chains: Optional[Iterable[Chain]]
+    min_balance: Optional[int]
+
+    def __init__(
+        self,
+        chains: Optional[Iterable[Chain]] = None,
+        min_balance: Optional[int] = None,
+    ):
+        self.chains = chains
+        self.min_balance = min_balance
+
+    def as_http_params(self) -> Dict[str, str]:
+        """Convert the filters into a dict that can be used by an `aiohttp` client
+        as `params` to build the HTTP query string.
+        """
+
+        partial_result = {
+            "chains": serialize_list(
+                [chain.value for chain in self.chains] if self.chains else None
+            ),
+            "min_balance": (
+                str(self.min_balance) if self.min_balance is not None else None
+            ),
+        }
+
+        # Ensure all values are strings.
+        result: Dict[str, str] = {}
+
+        # Drop empty values
+        for key, value in partial_result.items():
+            if value:
+                assert isinstance(value, str), f"Value must be a string: `{value}`"
+                result[key] = value
+
+        return result

--- a/src/aleph/sdk/query/filters.py
+++ b/src/aleph/sdk/query/filters.py
@@ -33,6 +33,13 @@ class SortByMessageType(str, Enum):
     TOTAL = "total"
 
 
+class FileType(str, Enum):
+    """Supported file types"""
+
+    FILE = "file"
+    DIRECTORY = "directory"
+
+
 class MessageFilter:
     """
     A collection of filters that can be applied on message queries.
@@ -274,6 +281,42 @@ class AddressesFilter:
             "addressContains": self.address_contains,
             "sortBy": enum_as_str(self.sort_by),
             "sortOrder": enum_as_str(self.sort_order),
+        }
+
+        # Ensure all values are strings.
+        result: Dict[str, str] = {}
+
+        # Drop empty values
+        for key, value in partial_result.items():
+            if value:
+                assert isinstance(value, str), f"Value must be a string: `{value}`"
+                result[key] = value
+
+        return result
+
+
+class AccountFilesFilter:
+    """
+    A collection of query parameters for account files queries.
+
+    :param sort_order: Sort order (ascending or descending by creation date)
+    """
+
+    sort_order: Optional[SortOrder]
+
+    def __init__(
+        self,
+        sort_order: Optional[SortOrder] = None,
+    ):
+        self.sort_order = sort_order
+
+    def as_http_params(self) -> Dict[str, str]:
+        """Convert the filters into a dict that can be used by an `aiohttp` client
+        as `params` to build the HTTP query string.
+        """
+
+        partial_result = {
+            "sort_order": enum_as_str(self.sort_order),
         }
 
         # Ensure all values are strings.

--- a/src/aleph/sdk/query/filters.py
+++ b/src/aleph/sdk/query/filters.py
@@ -21,6 +21,18 @@ class SortOrder(str, Enum):
     DESCENDING = "-1"
 
 
+class SortByMessageType(str, Enum):
+    """Supported SortByMessageType types for address stats"""
+
+    AGGREGATE = "aggregate"
+    FORGET = "forget"
+    INSTANCE = "instance"
+    POST = "post"
+    PROGRAM = "program"
+    STORE = "store"
+    TOTAL = "total"
+
+
 class MessageFilter:
     """
     A collection of filters that can be applied on message queries.
@@ -217,6 +229,52 @@ class BalanceFilter:
         """
 
         partial_result = {"chain": enum_as_str(self.chain)}
+
+        # Ensure all values are strings.
+        result: Dict[str, str] = {}
+
+        # Drop empty values
+        for key, value in partial_result.items():
+            if value:
+                assert isinstance(value, str), f"Value must be a string: `{value}`"
+                result[key] = value
+
+        return result
+
+
+class AddressesFilter:
+    """
+    A collection of query parameters for address stats queries.
+
+    :param address_contains: Case-insensitive substring to filter addresses
+    :param sort_by: Message type to sort by (aggregate, forget, instance, post, program, store, total)
+    :param sort_order: Sort order (ascending or descending)
+    """
+
+    address_contains: Optional[str]
+    sort_by: Optional[SortByMessageType]
+    sort_order: Optional[SortOrder]
+
+    def __init__(
+        self,
+        address_contains: Optional[str] = None,
+        sort_by: Optional[SortByMessageType] = None,
+        sort_order: Optional[SortOrder] = None,
+    ):
+        self.address_contains = address_contains
+        self.sort_by = sort_by
+        self.sort_order = sort_order
+
+    def as_http_params(self) -> Dict[str, str]:
+        """Convert the filters into a dict that can be used by an `aiohttp` client
+        as `params` to build the HTTP query string.
+        """
+
+        partial_result = {
+            "addressContains": self.address_contains,
+            "sortBy": enum_as_str(self.sort_by),
+            "sortOrder": enum_as_str(self.sort_order),
+        }
 
         # Ensure all values are strings.
         result: Dict[str, str] = {}

--- a/src/aleph/sdk/query/filters.py
+++ b/src/aleph/sdk/query/filters.py
@@ -33,13 +33,6 @@ class SortByMessageType(str, Enum):
     TOTAL = "total"
 
 
-class FileType(str, Enum):
-    """Supported file types"""
-
-    FILE = "file"
-    DIRECTORY = "directory"
-
-
 class MessageFilter:
     """
     A collection of filters that can be applied on message queries.
@@ -249,6 +242,11 @@ class BalanceFilter:
         return result
 
 
+def _drop_empty(partial: Dict[str, Optional[str]]) -> Dict[str, str]:
+    """Drop keys whose value is None or an empty string."""
+    return {key: value for key, value in partial.items() if value}
+
+
 class AddressesFilter:
     """
     A collection of query parameters for address stats queries.
@@ -276,23 +274,13 @@ class AddressesFilter:
         """Convert the filters into a dict that can be used by an `aiohttp` client
         as `params` to build the HTTP query string.
         """
-
-        partial_result = {
-            "addressContains": self.address_contains,
-            "sortBy": enum_as_str(self.sort_by),
-            "sortOrder": enum_as_str(self.sort_order),
-        }
-
-        # Ensure all values are strings.
-        result: Dict[str, str] = {}
-
-        # Drop empty values
-        for key, value in partial_result.items():
-            if value:
-                assert isinstance(value, str), f"Value must be a string: `{value}`"
-                result[key] = value
-
-        return result
+        return _drop_empty(
+            {
+                "addressContains": self.address_contains,
+                "sortBy": enum_as_str(self.sort_by),
+                "sortOrder": enum_as_str(self.sort_order),
+            }
+        )
 
 
 class AccountFilesFilter:
@@ -314,21 +302,7 @@ class AccountFilesFilter:
         """Convert the filters into a dict that can be used by an `aiohttp` client
         as `params` to build the HTTP query string.
         """
-
-        partial_result = {
-            "sort_order": enum_as_str(self.sort_order),
-        }
-
-        # Ensure all values are strings.
-        result: Dict[str, str] = {}
-
-        # Drop empty values
-        for key, value in partial_result.items():
-            if value:
-                assert isinstance(value, str), f"Value must be a string: `{value}`"
-                result[key] = value
-
-        return result
+        return _drop_empty({"sortOrder": enum_as_str(self.sort_order)})
 
 
 class ChainBalancesFilter:
@@ -337,6 +311,7 @@ class ChainBalancesFilter:
 
     :param chains: Filter by specific blockchain chains
     :param min_balance: Minimum balance required (must be >= 1)
+    :raises ValueError: If min_balance is provided and is less than 1
     """
 
     chains: Optional[Iterable[Chain]]
@@ -347,6 +322,8 @@ class ChainBalancesFilter:
         chains: Optional[Iterable[Chain]] = None,
         min_balance: Optional[int] = None,
     ):
+        if min_balance is not None and min_balance < 1:
+            raise ValueError(f"min_balance must be >= 1, got {min_balance}")
         self.chains = chains
         self.min_balance = min_balance
 
@@ -354,23 +331,13 @@ class ChainBalancesFilter:
         """Convert the filters into a dict that can be used by an `aiohttp` client
         as `params` to build the HTTP query string.
         """
-
-        partial_result = {
-            "chains": serialize_list(
-                [chain.value for chain in self.chains] if self.chains else None
-            ),
-            "min_balance": (
-                str(self.min_balance) if self.min_balance is not None else None
-            ),
-        }
-
-        # Ensure all values are strings.
-        result: Dict[str, str] = {}
-
-        # Drop empty values
-        for key, value in partial_result.items():
-            if value:
-                assert isinstance(value, str), f"Value must be a string: `{value}`"
-                result[key] = value
-
-        return result
+        return _drop_empty(
+            {
+                "chains": serialize_list(
+                    [chain.value for chain in self.chains] if self.chains else None
+                ),
+                "minBalance": (
+                    str(self.min_balance) if self.min_balance is not None else None
+                ),
+            }
+        )

--- a/src/aleph/sdk/query/responses.py
+++ b/src/aleph/sdk/query/responses.py
@@ -138,3 +138,28 @@ class BalanceResponse(BaseModel):
     details: Optional[Dict[str, Decimal]] = None
     locked_amount: Decimal
     credit_balance: int = 0
+
+
+class AddressStats(BaseModel):
+    """
+    Statistics for a single address showing message counts by type.
+    """
+
+    messages: int = Field(description="Total number of messages")
+    post: int = Field(description="Number of POST messages")
+    aggregate: int = Field(description="Number of AGGREGATE messages")
+    store: int = Field(description="Number of STORE messages")
+    forget: int = Field(description="Number of FORGET messages")
+    program: int = Field(description="Number of PROGRAM messages")
+    instance: int = Field(description="Number of INSTANCE messages")
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class AddressStatsResponse(PaginationResponse):
+    """Response from an aleph.im node API on the path /api/v1/addresses/stats.json"""
+
+    data: Dict[str, AddressStats] = Field(
+        description="Dictionary mapping addresses to their statistics"
+    )
+    pagination_item: str = "addresses"

--- a/src/aleph/sdk/query/responses.py
+++ b/src/aleph/sdk/query/responses.py
@@ -13,6 +13,8 @@ from aleph_message.models import (
 )
 from pydantic import BaseModel, ConfigDict, Field
 
+from aleph.sdk.query.filters import FileType
+
 
 class Post(BaseModel):
     """
@@ -163,3 +165,30 @@ class AddressStatsResponse(PaginationResponse):
         description="Dictionary mapping addresses to their statistics"
     )
     pagination_item: str = "addresses"
+
+
+class AccountFilesResponseItem(BaseModel):
+    """
+    A single file entry in an account's file list.
+    """
+
+    file_hash: str = Field(description="Hash of the file content")
+    size: int = Field(description="Size of the file in bytes")
+    type: FileType = Field(description="Type of the file (FILE or DIRECTORY)")
+    created: dt.datetime = Field(description="Timestamp when the file was created")
+    item_hash: str = Field(description="Hash of the message that created this file")
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class AccountFilesResponse(PaginationResponse):
+    """Response from an aleph.im node API on the path /api/v0/addresses/{address}/files"""
+
+    address: str = Field(description="The account address")
+    total_size: int = Field(description="Total size of all files in bytes")
+    files: List[AccountFilesResponseItem] = Field(
+        description="List of files owned by the address"
+    )
+    pagination_item: str = "files"
+
+    model_config = ConfigDict(extra="forbid")

--- a/src/aleph/sdk/query/responses.py
+++ b/src/aleph/sdk/query/responses.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 from decimal import Decimal
+from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 from aleph_message.models import (
@@ -13,7 +14,12 @@ from aleph_message.models import (
 )
 from pydantic import BaseModel, ConfigDict, Field
 
-from aleph.sdk.query.filters import FileType
+
+class FileType(str, Enum):
+    """Supported file types returned by the account-files endpoint."""
+
+    FILE = "file"
+    DIRECTORY = "directory"
 
 
 class Post(BaseModel):
@@ -159,7 +165,11 @@ class AddressStats(BaseModel):
 
 
 class AddressStatsResponse(PaginationResponse):
-    """Response from an aleph.im node API on the path /api/v1/addresses/stats.json"""
+    """Response from an aleph.im node API on the path /api/v1/addresses/stats.json.
+
+    Note: ``data`` is a mapping rather than a list, keyed by address string.
+    Iteration order is not guaranteed across pages.
+    """
 
     data: Dict[str, AddressStats] = Field(
         description="Dictionary mapping addresses to their statistics"
@@ -191,8 +201,6 @@ class AccountFilesResponse(PaginationResponse):
     )
     pagination_item: str = "files"
 
-    model_config = ConfigDict(extra="forbid")
-
 
 class AddressBalanceResponseItem(BaseModel):
     """
@@ -213,5 +221,3 @@ class ChainBalancesResponse(PaginationResponse):
         description="List of address balances across different chains"
     )
     pagination_item: str = "balances"
-
-    model_config = ConfigDict(extra="forbid")

--- a/src/aleph/sdk/query/responses.py
+++ b/src/aleph/sdk/query/responses.py
@@ -192,3 +192,26 @@ class AccountFilesResponse(PaginationResponse):
     pagination_item: str = "files"
 
     model_config = ConfigDict(extra="forbid")
+
+
+class AddressBalanceResponseItem(BaseModel):
+    """
+    A single balance entry for an address on a specific chain.
+    """
+
+    address: str = Field(description="The account address")
+    balance: Decimal = Field(description="Balance amount")
+    chain: Chain = Field(description="Blockchain the balance is on")
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ChainBalancesResponse(PaginationResponse):
+    """Response from an aleph.im node API on the path /api/v0/balances"""
+
+    balances: List[AddressBalanceResponseItem] = Field(
+        description="List of address balances across different chains"
+    )
+    pagination_item: str = "balances"
+
+    model_config = ConfigDict(extra="forbid")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -157,6 +157,60 @@ def raw_posts_response(json_post) -> Callable[[int], Dict[str, Any]]:
     }
 
 
+@pytest.fixture
+def address_stats_data() -> List[Dict[str, Any]]:
+    return [
+        {
+            "address": "0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10",
+            "post": 10,
+            "aggregate": 5,
+            "store": 3,
+            "forget": 0,
+            "program": 2,
+            "instance": 1,
+            "total": 21,
+        },
+        {
+            "address": "0x51A58800b26AA1451aaA803d1746687cB88E0501",
+            "post": 15,
+            "aggregate": 8,
+            "store": 6,
+            "forget": 1,
+            "program": 3,
+            "instance": 2,
+            "total": 35,
+        },
+    ]
+
+
+@pytest.fixture
+def raw_address_stats_response(
+    address_stats_data,
+) -> Callable[[int], Dict[str, Any]]:
+    # Convert list of address stats to dict format as returned by API
+    data_dict = {}
+    if int(1) == 1:  # page 1
+        for item in address_stats_data:
+            address = item["address"]
+            data_dict[address] = {
+                "messages": item["total"],
+                "post": item["post"],
+                "aggregate": item["aggregate"],
+                "store": item["store"],
+                "forget": item["forget"],
+                "program": item["program"],
+                "instance": item["instance"],
+            }
+
+    return lambda page: {
+        "data": data_dict if int(page) == 1 else {},
+        "pagination_item": "addresses",
+        "pagination_page": int(page),
+        "pagination_per_page": max(len(address_stats_data), 20),
+        "pagination_total": len(address_stats_data) if page == 1 else 0,
+    }
+
+
 class MockResponse:
     def __init__(self, sync: bool):
         self.sync = sync

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -211,6 +211,34 @@ def raw_address_stats_response(
     }
 
 
+@pytest.fixture
+def address_files_data() -> Dict[str, Any]:
+    return {
+        "address": "0xd463495a6FEaC9921FD0C3a595B81E7B2C02B24d",
+        "total_size": 2048000,
+        "files": [
+            {
+                "file_hash": "QmX1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0t1",
+                "size": 1024000,
+                "type": "file",
+                "created": "2024-01-15T10:30:00.000000",
+                "item_hash": "abc123def456",
+            },
+            {
+                "file_hash": "QmY9z8y7x6w5v4u3t2s1r0q9p8o7n6m5l4k3j2i1h0g9",
+                "size": 1024000,
+                "type": "directory",
+                "created": "2024-01-16T14:45:00.000000",
+                "item_hash": "xyz789uvw012",
+            },
+        ],
+        "pagination_page": 1,
+        "pagination_total": 2,
+        "pagination_per_page": 100,
+        "pagination_item": "files",
+    }
+
+
 class MockResponse:
     def __init__(self, sync: bool):
         self.sync = sync

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -239,6 +239,43 @@ def address_files_data() -> Dict[str, Any]:
     }
 
 
+@pytest.fixture
+def chain_balances_data() -> List[Dict[str, Any]]:
+    """Return mock data representing chain balances."""
+    return [
+        {
+            "address": "0x1234567890123456789012345678901234567890",
+            "balance": 1000.5,
+            "chain": "ETH",
+        },
+        {
+            "address": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+            "balance": 2500.75,
+            "chain": "ETH",
+        },
+        {
+            "address": "0x9876543210987654321098765432109876543210",
+            "balance": 500.0,
+            "chain": "AVAX",
+        },
+    ]
+
+
+@pytest.fixture
+def raw_chain_balances_response(
+    chain_balances_data: List[Dict[str, Any]],
+) -> Callable[[int], Dict[str, Any]]:
+    """Return a function that generates paginated chain balances API responses."""
+
+    return lambda page: {
+        "balances": chain_balances_data if int(page) == 1 else [],
+        "pagination_item": "balances",
+        "pagination_page": int(page),
+        "pagination_per_page": 100,
+        "pagination_total": len(chain_balances_data) if page == 1 else 0,
+    }
+
+
 class MockResponse:
     def __init__(self, sync: bool):
         self.sync = sync

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -159,26 +159,27 @@ def raw_posts_response(json_post) -> Callable[[int], Dict[str, Any]]:
 
 @pytest.fixture
 def address_stats_data() -> List[Dict[str, Any]]:
+    """Fixture data using the same field names as the actual API response."""
     return [
         {
             "address": "0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10",
+            "messages": 21,
             "post": 10,
             "aggregate": 5,
             "store": 3,
             "forget": 0,
             "program": 2,
             "instance": 1,
-            "total": 21,
         },
         {
             "address": "0x51A58800b26AA1451aaA803d1746687cB88E0501",
+            "messages": 35,
             "post": 15,
             "aggregate": 8,
             "store": 6,
             "forget": 1,
             "program": 3,
             "instance": 2,
-            "total": 35,
         },
     ]
 
@@ -187,17 +188,8 @@ def address_stats_data() -> List[Dict[str, Any]]:
 def raw_address_stats_response(
     address_stats_data,
 ) -> Callable[[int], Dict[str, Any]]:
-    # Convert list of address stats to dict format as returned by API
     data_dict = {
-        item["address"]: {
-            "messages": item["total"],
-            "post": item["post"],
-            "aggregate": item["aggregate"],
-            "store": item["store"],
-            "forget": item["forget"],
-            "program": item["program"],
-            "instance": item["instance"],
-        }
+        item["address"]: {k: v for k, v in item.items() if k != "address"}
         for item in address_stats_data
     }
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -188,26 +188,25 @@ def raw_address_stats_response(
     address_stats_data,
 ) -> Callable[[int], Dict[str, Any]]:
     # Convert list of address stats to dict format as returned by API
-    data_dict = {}
-    if int(1) == 1:  # page 1
-        for item in address_stats_data:
-            address = item["address"]
-            data_dict[address] = {
-                "messages": item["total"],
-                "post": item["post"],
-                "aggregate": item["aggregate"],
-                "store": item["store"],
-                "forget": item["forget"],
-                "program": item["program"],
-                "instance": item["instance"],
-            }
+    data_dict = {
+        item["address"]: {
+            "messages": item["total"],
+            "post": item["post"],
+            "aggregate": item["aggregate"],
+            "store": item["store"],
+            "forget": item["forget"],
+            "program": item["program"],
+            "instance": item["instance"],
+        }
+        for item in address_stats_data
+    }
 
     return lambda page: {
         "data": data_dict if int(page) == 1 else {},
         "pagination_item": "addresses",
         "pagination_page": int(page),
         "pagination_per_page": max(len(address_stats_data), 20),
-        "pagination_total": len(address_stats_data) if page == 1 else 0,
+        "pagination_total": len(address_stats_data) if int(page) == 1 else 0,
     }
 
 

--- a/tests/unit/test_asynchronous_get.py
+++ b/tests/unit/test_asynchronous_get.py
@@ -5,8 +5,14 @@ import pytest
 from aleph_message.models import MessagesResponse, MessageType
 
 from aleph.sdk.exceptions import ForgottenMessageError
-from aleph.sdk.query.filters import MessageFilter, PostFilter
-from aleph.sdk.query.responses import PostsResponse
+from aleph.sdk.query.filters import (
+    AddressesFilter,
+    MessageFilter,
+    PostFilter,
+    SortByMessageType,
+    SortOrder,
+)
+from aleph.sdk.query.responses import AddressStatsResponse, PostsResponse
 from tests.unit.conftest import make_mock_get_session
 
 
@@ -165,6 +171,54 @@ async def test_get_message_error(rejected_message):
         assert error
         assert error["error_code"] == rejected_message["error_code"]
         assert error["details"] == rejected_message["details"]
+
+
+@pytest.mark.asyncio
+async def test_get_address_stats(raw_address_stats_response, address_stats_data):
+    mock_session = make_mock_get_session(raw_address_stats_response(1))
+    async with mock_session as session:
+        response: AddressStatsResponse = await session.get_address_stats(
+            page_size=20,
+            page=1,
+            filter=AddressesFilter(
+                address_contains="0xa1",
+                sort_by=SortByMessageType.TOTAL,
+                sort_order=SortOrder.DESCENDING,
+            ),
+        )
+
+        address_stats = response.data
+        assert len(address_stats) == 2
+
+        # Get the first address from the stats data
+        first_address = address_stats_data[0]["address"]
+        assert first_address in address_stats
+        assert address_stats[first_address].messages == address_stats_data[0]["total"]
+        assert address_stats[first_address].post == address_stats_data[0]["post"]
+        assert (
+            address_stats[first_address].aggregate == address_stats_data[0]["aggregate"]
+        )
+        assert address_stats[first_address].store == address_stats_data[0]["store"]
+        assert address_stats[first_address].forget == address_stats_data[0]["forget"]
+        assert address_stats[first_address].program == address_stats_data[0]["program"]
+        assert (
+            address_stats[first_address].instance == address_stats_data[0]["instance"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_address_stats_without_filter(raw_address_stats_response):
+    mock_session = make_mock_get_session(raw_address_stats_response(1))
+    async with mock_session as session:
+        response: AddressStatsResponse = await session.get_address_stats(
+            page_size=20,
+            page=1,
+        )
+
+        address_stats = response.data
+        assert len(address_stats) == 2
+        assert response.pagination_page == 1
+        assert response.pagination_item == "addresses"
 
 
 if __name__ == "__main __":

--- a/tests/unit/test_asynchronous_get.py
+++ b/tests/unit/test_asynchronous_get.py
@@ -319,5 +319,60 @@ async def test_get_chain_balances_without_filter(raw_chain_balances_response):
         assert response.pagination_item == "balances"
 
 
+def test_addresses_filter_as_http_params():
+    f = AddressesFilter(
+        address_contains="0xabc",
+        sort_by=SortByMessageType.TOTAL,
+        sort_order=SortOrder.DESCENDING,
+    )
+    params = f.as_http_params()
+    assert params == {
+        "addressContains": "0xabc",
+        "sortBy": "total",
+        "sortOrder": "-1",
+    }
+
+
+def test_addresses_filter_drops_none_values():
+    assert AddressesFilter().as_http_params() == {}
+    assert AddressesFilter(address_contains="x").as_http_params() == {
+        "addressContains": "x"
+    }
+
+
+def test_account_files_filter_uses_camel_case():
+    f = AccountFilesFilter(sort_order=SortOrder.ASCENDING)
+    params = f.as_http_params()
+    assert params == {"sortOrder": "1"}
+
+
+def test_chain_balances_filter_as_http_params():
+    f = ChainBalancesFilter(chains=[Chain.ETH, Chain.AVAX], min_balance=10)
+    params = f.as_http_params()
+    assert params == {"chains": "ETH,AVAX", "minBalance": "10"}
+
+
+def test_chain_balances_filter_rejects_invalid_min_balance():
+    with pytest.raises(ValueError, match="min_balance must be >= 1"):
+        ChainBalancesFilter(min_balance=0)
+    with pytest.raises(ValueError, match="min_balance must be >= 1"):
+        ChainBalancesFilter(min_balance=-5)
+
+
+def test_chain_balances_filter_accepts_min_balance_one():
+    f = ChainBalancesFilter(min_balance=1)
+    assert f.as_http_params() == {"minBalance": "1"}
+
+
+@pytest.mark.asyncio
+async def test_get_account_files_rejects_path_traversal():
+    """address with path separators or .. must raise ValueError before any HTTP call."""
+    mock_session = make_mock_get_session({})
+    async with mock_session as session:
+        for bad_address in ["../etc/passwd", "foo/bar", "a\\b", "..foo"]:
+            with pytest.raises(ValueError, match="Invalid address"):
+                await session.get_account_files(address=bad_address)
+
+
 if __name__ == "__main __":
     unittest.main()

--- a/tests/unit/test_asynchronous_get.py
+++ b/tests/unit/test_asynchronous_get.py
@@ -200,7 +200,9 @@ async def test_get_address_stats(raw_address_stats_response, address_stats_data)
         # Get the first address from the stats data
         first_address = address_stats_data[0]["address"]
         assert first_address in address_stats
-        assert address_stats[first_address].messages == address_stats_data[0]["total"]
+        assert (
+            address_stats[first_address].messages == address_stats_data[0]["messages"]
+        )
         assert address_stats[first_address].post == address_stats_data[0]["post"]
         assert (
             address_stats[first_address].aggregate == address_stats_data[0]["aggregate"]
@@ -369,8 +371,23 @@ async def test_get_account_files_rejects_path_traversal():
     """address with path separators or .. must raise ValueError before any HTTP call."""
     mock_session = make_mock_get_session({})
     async with mock_session as session:
-        for bad_address in ["../etc/passwd", "foo/bar", "a\\b", "..foo"]:
+        for bad_address in [
+            "../etc/passwd",
+            "./etc/passwd",
+            "foo/bar",
+            "a\\b",
+            "..foo",
+        ]:
             with pytest.raises(ValueError, match="Invalid address"):
+                await session.get_account_files(address=bad_address)
+
+
+@pytest.mark.asyncio
+async def test_get_account_files_rejects_empty_address():
+    mock_session = make_mock_get_session({})
+    async with mock_session as session:
+        for bad_address in ["", "   ", "\t", "\n"]:
+            with pytest.raises(ValueError, match="must not be empty"):
                 await session.get_account_files(address=bad_address)
 
 

--- a/tests/unit/test_asynchronous_get.py
+++ b/tests/unit/test_asynchronous_get.py
@@ -2,12 +2,13 @@ import unittest
 from datetime import datetime
 
 import pytest
-from aleph_message.models import MessagesResponse, MessageType
+from aleph_message.models import Chain, MessagesResponse, MessageType
 
 from aleph.sdk.exceptions import ForgottenMessageError
 from aleph.sdk.query.filters import (
     AccountFilesFilter,
     AddressesFilter,
+    ChainBalancesFilter,
     MessageFilter,
     PostFilter,
     SortByMessageType,
@@ -16,6 +17,7 @@ from aleph.sdk.query.filters import (
 from aleph.sdk.query.responses import (
     AccountFilesResponse,
     AddressStatsResponse,
+    ChainBalancesResponse,
     PostsResponse,
 )
 from tests.unit.conftest import make_mock_get_session
@@ -276,6 +278,45 @@ async def test_get_account_files_without_filter():
         assert len(response.files) == 1
         assert response.pagination_page == 1
         assert response.pagination_item == "files"
+
+
+@pytest.mark.asyncio
+async def test_get_chain_balances(raw_chain_balances_response, chain_balances_data):
+    """Test the get_chain_balances endpoint with filters applied."""
+    mock_session = make_mock_get_session(raw_chain_balances_response(1))
+    async with mock_session as session:
+        response: ChainBalancesResponse = await session.get_chain_balances(
+            page_size=100,
+            page=1,
+            filter=ChainBalancesFilter(
+                chains=[Chain.ETH, Chain.AVAX],
+                min_balance=100,
+            ),
+        )
+
+        balances = response.balances
+        assert len(balances) == 3
+        assert balances[0].address == chain_balances_data[0]["address"]
+        assert float(balances[0].balance) == chain_balances_data[0]["balance"]
+        assert balances[0].chain == Chain.ETH
+        assert response.pagination_item == "balances"
+        assert response.pagination_page == 1
+        assert response.pagination_total == 3
+
+
+@pytest.mark.asyncio
+async def test_get_chain_balances_without_filter(raw_chain_balances_response):
+    """Test the get_chain_balances endpoint without filters."""
+    mock_session = make_mock_get_session(raw_chain_balances_response(1))
+    async with mock_session as session:
+        response: ChainBalancesResponse = await session.get_chain_balances(
+            page_size=100,
+            page=1,
+        )
+
+        assert len(response.balances) >= 0
+        assert response.pagination_page == 1
+        assert response.pagination_item == "balances"
 
 
 if __name__ == "__main __":

--- a/tests/unit/test_asynchronous_get.py
+++ b/tests/unit/test_asynchronous_get.py
@@ -6,13 +6,18 @@ from aleph_message.models import MessagesResponse, MessageType
 
 from aleph.sdk.exceptions import ForgottenMessageError
 from aleph.sdk.query.filters import (
+    AccountFilesFilter,
     AddressesFilter,
     MessageFilter,
     PostFilter,
     SortByMessageType,
     SortOrder,
 )
-from aleph.sdk.query.responses import AddressStatsResponse, PostsResponse
+from aleph.sdk.query.responses import (
+    AccountFilesResponse,
+    AddressStatsResponse,
+    PostsResponse,
+)
 from tests.unit.conftest import make_mock_get_session
 
 
@@ -219,6 +224,58 @@ async def test_get_address_stats_without_filter(raw_address_stats_response):
         assert len(address_stats) == 2
         assert response.pagination_page == 1
         assert response.pagination_item == "addresses"
+
+
+@pytest.mark.asyncio
+async def test_get_account_files(address_files_data):
+    mock_session = make_mock_get_session(address_files_data)
+    async with mock_session as session:
+        response: AccountFilesResponse = await session.get_account_files(
+            address="0xd463495a6FEaC9921FD0C3a595B81E7B2C02B24d",
+            page_size=100,
+            page=1,
+            filter=AccountFilesFilter(sort_order=SortOrder.DESCENDING),
+        )
+
+        files = response.files
+        assert len(files) >= 1
+        assert response.address
+        assert response.total_size >= 0
+        assert response.pagination_item == "files"
+
+
+@pytest.mark.asyncio
+async def test_get_account_files_without_filter():
+    address = "0xd463495a6FEaC9921FD0C3a595B81E7B2C02B24d"
+    files_data = {
+        "address": address,
+        "total_size": 1024000,
+        "files": [
+            {
+                "file_hash": "QmTest",
+                "size": 1024000,
+                "type": "file",
+                "created": "2024-01-15T10:30:00",
+                "item_hash": "testitem",
+            }
+        ],
+        "pagination_page": 1,
+        "pagination_total": 1,
+        "pagination_per_page": 100,
+        "pagination_item": "files",
+    }
+
+    mock_session = make_mock_get_session(files_data)
+    async with mock_session as session:
+        response: AccountFilesResponse = await session.get_account_files(
+            address=address,
+            page_size=100,
+            page=1,
+        )
+
+        assert len(response.files) == 1
+        assert response.pagination_page == 1
+        assert response.pagination_item == "files"
 
 
 if __name__ == "__main __":


### PR DESCRIPTION
This pull request adds support for querying address statistics from the Aleph node API, including filtering and sorting capabilities. It introduces new models and filters for handling address stats, updates the HTTP client to support these queries, and adds comprehensive unit tests for the new functionality.

**Address stats query feature:**

* Added a new `AddressesFilter` class to `src/aleph/sdk/query/filters.py` for filtering and sorting address stats queries, including options for substring filtering and sorting by message type and order.
* Introduced the `SortByMessageType` enum to specify supported sort fields in address stats queries.
* Implemented the `AddressStats` and `AddressStatsResponse` models in `src/aleph/sdk/query/responses.py` to represent address statistics and the paginated response structure.
* Updated the HTTP client in `src/aleph/sdk/client/http.py` to add the `get_address_stats` method, allowing asynchronous retrieval of address statistics with filtering and pagination support. [[1]](diffhunk://#diff-98b2f220317fe0379eef848b853313affd30595845e3c4483da9fdb54cdc3a4bR731-R761) [[2]](diffhunk://#diff-98b2f220317fe0379eef848b853313affd30595845e3c4483da9fdb54cdc3a4bL55-R57)

**Testing and validation:**

* Added unit tests in `tests/unit/test_asynchronous_get.py` to verify the new address stats query functionality, including tests for filtered and unfiltered queries, and introduced fixtures in `tests/unit/conftest.py` to provide mock address stats data and responses. [[1]](diffhunk://#diff-2639bf9b7e8b37d16d2b7bc98a2e85e7b51600f8329276805b962b194e117f6bR133-R180) [[2]](diffhunk://#diff-2639bf9b7e8b37d16d2b7bc98a2e85e7b51600f8329276805b962b194e117f6bL8-R15) [[3]](diffhunk://#diff-0cae8a7ee2d37098b1ad84b543d17cfc1e8535eed5fd6abac88c668bfe354cbbR160-R213)