### PR TITLE
Add new methods to manage instance server (reinstall, backup create, info, download, delete )

### DIFF
--- a/src/aleph/sdk/client/vm_client.py
+++ b/src/aleph/sdk/client/vm_client.py
@@ -124,7 +124,9 @@ class VmClient:
 
         try:
             request_kwargs: Dict[str, Any] = {
-                "method": method, "url": url, "headers": header,
+                "method": method,
+                "url": url,
+                "headers": header,
             }
             if params:
                 request_kwargs["params"] = params

--- a/src/aleph/sdk/client/vm_client.py
+++ b/src/aleph/sdk/client/vm_client.py
@@ -218,9 +218,10 @@ class VmClient:
     async def reinstall_instance(
         self, vm_id: ItemHash, erase_volumes: bool = True
     ) -> Tuple[Optional[int], str]:
-        params = None if erase_volumes else {"erase_volumes": "false"}
         return await self.perform_operation(
-            vm_id, VmOperation.REINSTALL, params=params
+            vm_id,
+            VmOperation.REINSTALL,
+            params={"erase_volumes": str(erase_volumes).lower()},
         )
 
     async def create_backup(
@@ -229,19 +230,17 @@ class VmClient:
         include_volumes: bool = False,
         skip_fsfreeze: bool = False,
     ) -> Tuple[Optional[int], str]:
-        params: Dict[str, str] = {}
-        if include_volumes:
-            params["include_volumes"] = "true"
-        if skip_fsfreeze:
-            params["skip_fsfreeze"] = "true"
-        return await self.perform_operation(
-            vm_id, VmOperation.BACKUP, params=params
-        )
+        params: Optional[Dict[str, str]] = None
+        if include_volumes or skip_fsfreeze:
+            params = {}
+            if include_volumes:
+                params["include_volumes"] = "true"
+            if skip_fsfreeze:
+                params["skip_fsfreeze"] = "true"
+        return await self.perform_operation(vm_id, VmOperation.BACKUP, params=params)
 
     async def get_backup(self, vm_id: ItemHash) -> Tuple[Optional[int], str]:
-        return await self.perform_operation(
-            vm_id, VmOperation.BACKUP, method="GET"
-        )
+        return await self.perform_operation(vm_id, VmOperation.BACKUP, method="GET")
 
     async def delete_backup(
         self, vm_id: ItemHash, backup_id: str
@@ -255,9 +254,7 @@ class VmClient:
             vm_id, f"backup/{backup_id}", method="DELETE"
         )
 
-    async def get_restore_endpoint(
-        self, vm_id: ItemHash
-    ) -> Tuple[str, Dict[str, str]]:
+    async def get_restore_endpoint(self, vm_id: ItemHash) -> Tuple[str, Dict[str, str]]:
         """Return authenticated (url, headers) for a restore POST.
 
         Use this when you need control over the upload (e.g. progress
@@ -288,8 +285,8 @@ class VmClient:
                 ) as response:
                     text = await response.text()
                     return response.status, text
-        except aiohttp.ClientError as e:
-            logger.error(f"HTTP error during restore: {str(e)}")
+        except (aiohttp.ClientError, OSError) as e:
+            logger.error(f"Error during restore: {e}")
             return None, str(e)
 
     async def restore_from_volume(

--- a/src/aleph/sdk/client/vm_client.py
+++ b/src/aleph/sdk/client/vm_client.py
@@ -1,8 +1,10 @@
 import datetime
 import json
 import logging
+import re
+from enum import Enum
 from pathlib import Path
-from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple
+from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import aiohttp
@@ -20,6 +22,22 @@ from aleph.sdk.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+_BACKUP_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+class VmOperation(str, Enum):
+    STOP = "stop"
+    REBOOT = "reboot"
+    ERASE = "erase"
+    BACKUP = "backup"
+    RESTORE = "restore"
+    REINSTALL = "reinstall"
+    EXPIRE = "expire"
+    STREAM_LOGS = "stream_logs"
+
+    def __str__(self) -> str:
+        return self.value
 
 
 class VmClient:
@@ -112,12 +130,8 @@ class VmClient:
         operation: str,
         method: str = "POST",
         params: Optional[Dict[str, str]] = None,
+        json_data: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Optional[int], str]:
-        if not self.pubkey_signature_header:
-            self.pubkey_signature_header = (
-                await self._generate_pubkey_signature_header()
-            )
-
         url, header = await self._generate_header(
             vm_id=vm_id, operation=operation, method=method
         )
@@ -130,6 +144,8 @@ class VmClient:
             }
             if params:
                 request_kwargs["params"] = params
+            if json_data is not None:
+                request_kwargs["json"] = json_data
             async with self.session.request(**request_kwargs) as response:
                 response_text = await response.text()
                 return response.status, response_text
@@ -149,11 +165,6 @@ class VmClient:
         """
 
         async def authenticated_request():
-            if not self.pubkey_signature_header:
-                self.pubkey_signature_header = (
-                    await self._generate_pubkey_signature_header()
-                )
-
             url, header = await self._generate_header(
                 vm_id=vm_id, operation=operation, method=method
             )
@@ -171,7 +182,7 @@ class VmClient:
             )
 
         payload = create_vm_control_payload(
-            vm_id, "stream_logs", method="get", domain=self.node_domain
+            vm_id, VmOperation.STREAM_LOGS, method="get", domain=self.node_domain
         )
         signed_operation = sign_vm_control_payload(payload, self.ephemeral_key)
         path = payload["path"]
@@ -196,92 +207,87 @@ class VmClient:
         return await self.notify_allocation(vm_id)
 
     async def stop_instance(self, vm_id: ItemHash) -> Tuple[Optional[int], str]:
-        return await self.perform_operation(vm_id, "stop")
+        return await self.perform_operation(vm_id, VmOperation.STOP)
 
     async def reboot_instance(self, vm_id: ItemHash) -> Tuple[Optional[int], str]:
-        return await self.perform_operation(vm_id, "reboot")
+        return await self.perform_operation(vm_id, VmOperation.REBOOT)
 
     async def erase_instance(self, vm_id: ItemHash) -> Tuple[Optional[int], str]:
-        return await self.perform_operation(vm_id, "erase")
+        return await self.perform_operation(vm_id, VmOperation.ERASE)
 
     async def reinstall_instance(
         self, vm_id: ItemHash, erase_volumes: bool = True
     ) -> Tuple[Optional[int], str]:
         params = None if erase_volumes else {"erase_volumes": "false"}
-        return await self.perform_operation(vm_id, "reinstall", params=params)
+        return await self.perform_operation(
+            vm_id, VmOperation.REINSTALL, params=params
+        )
 
     async def create_backup(
         self,
         vm_id: ItemHash,
         include_volumes: bool = False,
         skip_fsfreeze: bool = False,
-        run_async: bool = False,
     ) -> Tuple[Optional[int], str]:
         params: Dict[str, str] = {}
-        if run_async:
-            params["async"] = "true"
         if include_volumes:
             params["include_volumes"] = "true"
         if skip_fsfreeze:
             params["skip_fsfreeze"] = "true"
-        return await self.perform_operation(vm_id, "backup", params=params or None)
+        return await self.perform_operation(
+            vm_id, VmOperation.BACKUP, params=params
+        )
 
     async def get_backup(self, vm_id: ItemHash) -> Tuple[Optional[int], str]:
-        return await self.perform_operation(vm_id, "backup", method="GET")
+        return await self.perform_operation(
+            vm_id, VmOperation.BACKUP, method="GET"
+        )
 
     async def delete_backup(
         self, vm_id: ItemHash, backup_id: str
     ) -> Tuple[Optional[int], str]:
-        if not self.pubkey_signature_header:
-            self.pubkey_signature_header = (
-                await self._generate_pubkey_signature_header()
+        if not _BACKUP_ID_RE.match(backup_id):
+            raise ValueError(
+                f"Invalid backup_id {backup_id!r}: "
+                "must contain only alphanumeric characters, hyphens, or underscores"
             )
-        url, header = await self._generate_header(
-            vm_id=vm_id, operation=f"backup/{backup_id}", method="DELETE"
+        return await self.perform_operation(
+            vm_id, f"backup/{backup_id}", method="DELETE"
         )
-        try:
-            async with self.session.delete(url, headers=header) as response:
-                text = await response.text()
-                return response.status, text
-        except aiohttp.ClientError as e:
-            logger.error(f"HTTP error during backup delete: {str(e)}")
-            return None, str(e)
 
-    async def get_restore_endpoint(self, vm_id: ItemHash) -> Tuple[str, Dict[str, str]]:
+    async def get_restore_endpoint(
+        self, vm_id: ItemHash
+    ) -> Tuple[str, Dict[str, str]]:
         """Return authenticated (url, headers) for a restore POST.
 
         Use this when you need control over the upload (e.g. progress
         tracking). For a simple restore, use restore_from_file instead.
         """
-        if not self.pubkey_signature_header:
-            self.pubkey_signature_header = (
-                await self._generate_pubkey_signature_header()
-            )
         return await self._generate_header(
-            vm_id=vm_id, operation="restore", method="POST"
+            vm_id=vm_id, operation=VmOperation.RESTORE, method="POST"
         )
 
     async def restore_from_file(
-        self, vm_id: ItemHash, rootfs_path: str
+        self, vm_id: ItemHash, rootfs_path: Union[str, Path]
     ) -> Tuple[Optional[int], str]:
-        if not self.pubkey_signature_header:
-            self.pubkey_signature_header = (
-                await self._generate_pubkey_signature_header()
-            )
         url, header = await self._generate_header(
-            vm_id=vm_id, operation="restore", method="POST"
+            vm_id=vm_id, operation=VmOperation.RESTORE, method="POST"
         )
-        data = aiohttp.FormData()
-        data.add_field(
-            "rootfs",
-            open(rootfs_path, "rb"),
-            filename=Path(rootfs_path).name,
-            content_type="application/octet-stream",
-        )
+        rootfs_path = Path(rootfs_path)
         try:
-            async with self.session.post(url, headers=header, data=data) as response:
-                text = await response.text()
-                return response.status, text
+            with open(rootfs_path, "rb") as f:
+                data = aiohttp.FormData()
+                data.add_field(
+                    "rootfs",
+                    f,
+                    filename=rootfs_path.name,
+                    content_type="application/octet-stream",
+                )
+                async with self.session.post(
+                    url, headers=header, data=data
+                ) as response:
+                    text = await response.text()
+                    return response.status, text
         except aiohttp.ClientError as e:
             logger.error(f"HTTP error during restore: {str(e)}")
             return None, str(e)
@@ -289,26 +295,14 @@ class VmClient:
     async def restore_from_volume(
         self, vm_id: ItemHash, volume_ref: str
     ) -> Tuple[Optional[int], str]:
-        if not self.pubkey_signature_header:
-            self.pubkey_signature_header = (
-                await self._generate_pubkey_signature_header()
-            )
-        url, header = await self._generate_header(
-            vm_id=vm_id, operation="restore", method="POST"
+        return await self.perform_operation(
+            vm_id,
+            VmOperation.RESTORE,
+            json_data={"volume_ref": volume_ref},
         )
-        header["Content-Type"] = "application/json"
-        try:
-            async with self.session.post(
-                url, headers=header, json={"volume_ref": volume_ref}
-            ) as response:
-                text = await response.text()
-                return response.status, text
-        except aiohttp.ClientError as e:
-            logger.error(f"HTTP error during restore: {str(e)}")
-            return None, str(e)
 
     async def expire_instance(self, vm_id: ItemHash) -> Tuple[Optional[int], str]:
-        return await self.perform_operation(vm_id, "expire")
+        return await self.perform_operation(vm_id, VmOperation.EXPIRE)
 
     async def notify_allocation(self, vm_id: ItemHash) -> Tuple[int, str]:
         json_data = {"instance": vm_id}

--- a/src/aleph/sdk/client/vm_client.py
+++ b/src/aleph/sdk/client/vm_client.py
@@ -123,9 +123,12 @@ class VmClient:
         )
 
         try:
-            async with self.session.request(
-                method=method, url=url, headers=header, params=params
-            ) as response:
+            request_kwargs: Dict[str, Any] = {
+                "method": method, "url": url, "headers": header,
+            }
+            if params:
+                request_kwargs["params"] = params
+            async with self.session.request(**request_kwargs) as response:
                 response_text = await response.text()
                 return response.status, response_text
 

--- a/src/aleph/sdk/client/vm_client.py
+++ b/src/aleph/sdk/client/vm_client.py
@@ -312,7 +312,7 @@ class VmClient:
             return session.status, form_response_text
 
     async def manage_instance(
-        self, vm_id: ItemHash, operations: List[str]
+        self, vm_id: ItemHash, operations: List[Union[VmOperation, str]]
     ) -> Tuple[int, str]:
         for operation in operations:
             status, response = await self.perform_operation(vm_id, operation)

--- a/tests/unit/test_vm_client.py
+++ b/tests/unit/test_vm_client.py
@@ -1,3 +1,4 @@
+import re
 from urllib.parse import urlparse
 
 import aiohttp
@@ -8,7 +9,7 @@ from aleph_message.models import ItemHash
 from yarl import URL
 
 from aleph.sdk.chains.ethereum import ETHAccount
-from aleph.sdk.client.vm_client import VmClient
+from aleph.sdk.client.vm_client import VmClient, VmOperation
 
 from .aleph_vm_authentication import (
     SignedOperation,
@@ -295,3 +296,236 @@ async def test_vm_client_generate_correct_authentication_headers():
     address = verify_signed_operation(signed_operation, signed_pubkey)
 
     assert vm_client.account.get_address() == address
+
+
+@pytest.mark.asyncio
+async def test_reinstall_instance():
+    account = ETHAccount(private_key=b"0x" + b"1" * 30)
+    vm_id = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
+
+    with aioresponses() as m:
+        vm_client = VmClient(
+            account=account,
+            node_url="http://localhost",
+            session=aiohttp.ClientSession(),
+        )
+        m.post(
+            f"http://localhost/control/machine/{vm_id}/reinstall",
+            status=200,
+            payload="ok",
+        )
+
+        status, response_text = await vm_client.reinstall_instance(vm_id)
+        assert status == 200
+        await vm_client.session.close()
+
+
+@pytest.mark.asyncio
+async def test_reinstall_instance_keep_volumes():
+    account = ETHAccount(private_key=b"0x" + b"1" * 30)
+    vm_id = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
+
+    with aioresponses() as m:
+        vm_client = VmClient(
+            account=account,
+            node_url="http://localhost",
+            session=aiohttp.ClientSession(),
+        )
+        m.post(
+            re.compile(rf"http://localhost/control/machine/{vm_id}/reinstall"),
+            status=200,
+            payload="ok",
+        )
+
+        status, _ = await vm_client.reinstall_instance(vm_id, erase_volumes=False)
+        assert status == 200
+        await vm_client.session.close()
+
+
+@pytest.mark.asyncio
+async def test_create_backup():
+    account = ETHAccount(private_key=b"0x" + b"1" * 30)
+    vm_id = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
+
+    with aioresponses() as m:
+        vm_client = VmClient(
+            account=account,
+            node_url="http://localhost",
+            session=aiohttp.ClientSession(),
+        )
+        m.post(
+            f"http://localhost/control/machine/{vm_id}/backup",
+            status=200,
+            payload="backup_created",
+        )
+
+        status, response_text = await vm_client.create_backup(vm_id)
+        assert status == 200
+        await vm_client.session.close()
+
+
+@pytest.mark.asyncio
+async def test_create_backup_with_options():
+    account = ETHAccount(private_key=b"0x" + b"1" * 30)
+    vm_id = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
+
+    with aioresponses() as m:
+        vm_client = VmClient(
+            account=account,
+            node_url="http://localhost",
+            session=aiohttp.ClientSession(),
+        )
+        m.post(
+            re.compile(rf"http://localhost/control/machine/{vm_id}/backup"),
+            status=200,
+            payload="backup_created",
+        )
+
+        status, _ = await vm_client.create_backup(
+            vm_id, include_volumes=True, skip_fsfreeze=True
+        )
+        assert status == 200
+        await vm_client.session.close()
+
+
+@pytest.mark.asyncio
+async def test_get_backup():
+    account = ETHAccount(private_key=b"0x" + b"1" * 30)
+    vm_id = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
+
+    with aioresponses() as m:
+        vm_client = VmClient(
+            account=account,
+            node_url="http://localhost",
+            session=aiohttp.ClientSession(),
+        )
+        m.get(
+            f"http://localhost/control/machine/{vm_id}/backup",
+            status=200,
+            payload={"backups": []},
+        )
+
+        status, response_text = await vm_client.get_backup(vm_id)
+        assert status == 200
+        await vm_client.session.close()
+
+
+@pytest.mark.asyncio
+async def test_delete_backup():
+    account = ETHAccount(private_key=b"0x" + b"1" * 30)
+    vm_id = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
+    backup_id = "abc123"
+
+    with aioresponses() as m:
+        vm_client = VmClient(
+            account=account,
+            node_url="http://localhost",
+            session=aiohttp.ClientSession(),
+        )
+        m.delete(
+            f"http://localhost/control/machine/{vm_id}/backup/{backup_id}",
+            status=200,
+            payload="deleted",
+        )
+
+        status, response_text = await vm_client.delete_backup(vm_id, backup_id)
+        assert status == 200
+        await vm_client.session.close()
+
+
+@pytest.mark.asyncio
+async def test_delete_backup_invalid_id():
+    account = ETHAccount(private_key=b"0x" + b"1" * 30)
+    vm_id = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
+
+    vm_client = VmClient(
+        account=account,
+        node_url="http://localhost",
+        session=aiohttp.ClientSession(),
+    )
+
+    with pytest.raises(ValueError, match="Invalid backup_id"):
+        await vm_client.delete_backup(vm_id, "../etc/passwd")
+
+    with pytest.raises(ValueError, match="Invalid backup_id"):
+        await vm_client.delete_backup(vm_id, "id/with/slashes")
+
+    await vm_client.session.close()
+
+
+@pytest.mark.asyncio
+async def test_get_restore_endpoint():
+    account = ETHAccount(private_key=b"0x" + b"1" * 30)
+    vm_id = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
+
+    vm_client = VmClient(
+        account=account,
+        node_url="http://localhost",
+        session=aiohttp.ClientSession(),
+    )
+
+    url, headers = await vm_client.get_restore_endpoint(vm_id)
+    assert f"/control/machine/{vm_id}/restore" in url
+    assert "X-SignedPubKey" in headers
+    assert "X-SignedOperation" in headers
+    await vm_client.session.close()
+
+
+@pytest.mark.asyncio
+async def test_restore_from_volume():
+    account = ETHAccount(private_key=b"0x" + b"1" * 30)
+    vm_id = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
+
+    with aioresponses() as m:
+        vm_client = VmClient(
+            account=account,
+            node_url="http://localhost",
+            session=aiohttp.ClientSession(),
+        )
+        m.post(
+            f"http://localhost/control/machine/{vm_id}/restore",
+            status=200,
+            payload="restored",
+        )
+
+        status, response_text = await vm_client.restore_from_volume(
+            vm_id, "volume_hash_abc123"
+        )
+        assert status == 200
+        await vm_client.session.close()
+
+
+@pytest.mark.asyncio
+async def test_restore_from_file(tmp_path):
+    account = ETHAccount(private_key=b"0x" + b"1" * 30)
+    vm_id = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
+
+    rootfs = tmp_path / "rootfs.img"
+    rootfs.write_bytes(b"fake rootfs content")
+
+    with aioresponses() as m:
+        vm_client = VmClient(
+            account=account,
+            node_url="http://localhost",
+            session=aiohttp.ClientSession(),
+        )
+        m.post(
+            f"http://localhost/control/machine/{vm_id}/restore",
+            status=200,
+            payload="restored",
+        )
+
+        status, response_text = await vm_client.restore_from_file(vm_id, rootfs)
+        assert status == 200
+        await vm_client.session.close()
+
+
+def test_vm_operation_enum_values():
+    assert VmOperation.STOP == "stop"
+    assert VmOperation.REBOOT == "reboot"
+    assert VmOperation.ERASE == "erase"
+    assert VmOperation.BACKUP == "backup"
+    assert VmOperation.RESTORE == "restore"
+    assert VmOperation.REINSTALL == "reinstall"
+    assert VmOperation.EXPIRE == "expire"
+    assert VmOperation.STREAM_LOGS == "stream_logs"

--- a/tests/unit/test_vm_client.py
+++ b/tests/unit/test_vm_client.py
@@ -387,6 +387,8 @@ async def test_create_backup_with_options():
             vm_id, include_volumes=True, skip_fsfreeze=True
         )
         assert status == 200
+        assert any("include_volumes=true" in str(k[1]) for k in m.requests)
+        assert any("skip_fsfreeze=true" in str(k[1]) for k in m.requests)
         await vm_client.session.close()
 
 

--- a/tests/unit/test_vm_client.py
+++ b/tests/unit/test_vm_client.py
@@ -310,13 +310,14 @@ async def test_reinstall_instance():
             session=aiohttp.ClientSession(),
         )
         m.post(
-            f"http://localhost/control/machine/{vm_id}/reinstall",
+            re.compile(rf"http://localhost/control/machine/{vm_id}/reinstall"),
             status=200,
             payload="ok",
         )
 
         status, response_text = await vm_client.reinstall_instance(vm_id)
         assert status == 200
+        assert any("erase_volumes=true" in str(k[1]) for k in m.requests)
         await vm_client.session.close()
 
 
@@ -339,6 +340,7 @@ async def test_reinstall_instance_keep_volumes():
 
         status, _ = await vm_client.reinstall_instance(vm_id, erase_volumes=False)
         assert status == 200
+        assert any("erase_volumes=false" in str(k[1]) for k in m.requests)
         await vm_client.session.close()
 
 
@@ -518,6 +520,25 @@ async def test_restore_from_file(tmp_path):
         status, response_text = await vm_client.restore_from_file(vm_id, rootfs)
         assert status == 200
         await vm_client.session.close()
+
+
+@pytest.mark.asyncio
+async def test_restore_from_file_not_found():
+    account = ETHAccount(private_key=b"0x" + b"1" * 30)
+    vm_id = ItemHash("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe")
+
+    vm_client = VmClient(
+        account=account,
+        node_url="http://localhost",
+        session=aiohttp.ClientSession(),
+    )
+
+    status, error_text = await vm_client.restore_from_file(
+        vm_id, "/nonexistent/rootfs.img"
+    )
+    assert status is None
+    assert "No such file or directory" in error_text
+    await vm_client.session.close()
 
 
 def test_vm_operation_enum_values():


### PR DESCRIPTION
### This PR add new methods to perform new actions on an instance

- reinstall_instance to reinstall an existing instance to its initial state
- create_backup to create a backup of an instance and return a pre-signed download link
- get_backup to get backup info if it exists and return a pre-signed download link
- restore_from_file to restore an instance from a provided rootfs file
- restore_from_volume to restore an instance from a pinned volume

related to:
https://github.com/aleph-im/aleph-vm/pull/874