### PR TITLE
feat: authenticated IPFS uploads with client-side CID computation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dynamic = [ "version" ]
 dependencies = [
   "aiohttp>=3.8.3",
   "aioresponses>=0.7.6",
+  "aleph-cid>=0.1",
   "aleph-message>=1.1.1",
   "aleph-superfluid>=0.3",
   "base58==2.1.1",                         # Needed now as default with _load_account changement

--- a/src/aleph/sdk/client/authenticated_http.py
+++ b/src/aleph/sdk/client/authenticated_http.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, Mapping, NoReturn, Optional, Tuple, Union
 
 import aiohttp
+import aleph_cid
 from aleph_message.models import (
     AggregateContent,
     AggregateMessage,
@@ -51,15 +52,6 @@ try:
 except ImportError:
     logger.info("Could not import library 'magic', MIME type detection disabled")
     magic = None  # type:ignore
-
-try:
-    import aleph_cid
-except ImportError:
-    logger.info(
-        "Could not import library 'aleph_cid', "
-        "authenticated IPFS uploads disabled (legacy unauthenticated path used)"
-    )
-    aleph_cid = None  # type:ignore
 
 
 class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
@@ -393,26 +385,18 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
                     payment=payment,
                 )
             elif storage_engine == StorageEnum.ipfs:
-                if aleph_cid is not None:
-                    # Compute the CID locally and upload the file and message
-                    # all at once using authenticated upload.
-                    return await self._upload_file_ipfs(
-                        address=address,
-                        file_content=file_content,
-                        guess_mime_type=guess_mime_type,
-                        ref=ref,
-                        extra_fields=extra_fields,
-                        channel=channel,
-                        sync=sync,
-                        payment=payment,
-                    )
-                # Without aleph-cid we cannot compute the CID client-side. Use
-                # the legacy method of uploading the file first then publishing
-                # the message using POST /messages.
-                logger.warning(
-                    "aleph-cid is not installed, falling back to unauthenticated IPFS upload"
+                # Compute the CID locally and upload the file and message all
+                # at once using authenticated upload.
+                return await self._upload_file_ipfs(
+                    address=address,
+                    file_content=file_content,
+                    guess_mime_type=guess_mime_type,
+                    ref=ref,
+                    extra_fields=extra_fields,
+                    channel=channel,
+                    sync=sync,
+                    payment=payment,
                 )
-                file_hash = await self.ipfs_push_file(file_content=file_content)
             else:
                 raise ValueError(f"Unknown storage engine: '{storage_engine}'")
 
@@ -797,8 +781,7 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         CID that kubo would assign, CIDv1) and posted to
         /api/v0/ipfs/add_car together with the signed STORE message.
 
-        Requires the `aleph-cid` package and a node exposing
-        /api/v0/ipfs/add_car.
+        Requires a node exposing /api/v0/ipfs/add_car.
 
         :param folder_path: Path to the folder to upload
         :param address: Address to use or None to use the account address
@@ -808,11 +791,6 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         :param sync: If true, waits for the message to be processed by the API server
         :param payment: Payment method used to pay for the storage
         """
-        if aleph_cid is None:
-            raise RuntimeError(
-                "Folder uploads require the 'aleph-cid' package: pip install aleph-cid"
-            )
-
         folder_path = Path(folder_path)
         if not folder_path.is_dir():
             raise ValueError(f"Not a directory: {folder_path}")

--- a/src/aleph/sdk/client/authenticated_http.py
+++ b/src/aleph/sdk/client/authenticated_http.py
@@ -1,7 +1,9 @@
+import asyncio
 import hashlib
 import json
 import logging
 import ssl
+import tempfile
 import time
 from io import BytesIO
 from pathlib import Path
@@ -49,6 +51,15 @@ try:
 except ImportError:
     logger.info("Could not import library 'magic', MIME type detection disabled")
     magic = None  # type:ignore
+
+try:
+    import aleph_cid
+except ImportError:
+    logger.info(
+        "Could not import library 'aleph_cid', "
+        "authenticated IPFS uploads disabled (legacy unauthenticated path used)"
+    )
+    aleph_cid = None  # type:ignore
 
 
 class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
@@ -382,8 +393,25 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
                     payment=payment,
                 )
             elif storage_engine == StorageEnum.ipfs:
-                # We do not support authenticated upload for IPFS yet. Use the legacy method
-                # of uploading the file first then publishing the message using POST /messages.
+                if aleph_cid is not None:
+                    # Compute the CID locally and upload the file and message
+                    # all at once using authenticated upload.
+                    return await self._upload_file_ipfs(
+                        address=address,
+                        file_content=file_content,
+                        guess_mime_type=guess_mime_type,
+                        ref=ref,
+                        extra_fields=extra_fields,
+                        channel=channel,
+                        sync=sync,
+                        payment=payment,
+                    )
+                # Without aleph-cid we cannot compute the CID client-side. Use
+                # the legacy method of uploading the file first then publishing
+                # the message using POST /messages.
+                logger.warning(
+                    "aleph-cid is not installed, falling back to unauthenticated IPFS upload"
+                )
                 file_hash = await self.ipfs_push_file(file_content=file_content)
             else:
                 raise ValueError(f"Unknown storage engine: '{storage_engine}'")
@@ -620,14 +648,18 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         )
         return message, message_status, response
 
-    async def _storage_push_file_with_message(
+    async def _push_file_with_message(
         self,
+        url: str,
         file_content: bytes,
         store_content: StoreContent,
         channel: Optional[str] = settings.DEFAULT_CHANNEL,
         sync: bool = False,
+        file_name: Optional[str] = None,
+        file_content_type: Optional[str] = None,
     ) -> Tuple[StoreMessage, MessageStatus]:
-        """Push a file to the storage service."""
+        """Sign a STORE message and upload it together with the file in a
+        single authenticated multipart request."""
         data = aiohttp.FormData()
 
         # Prepare the STORE message
@@ -646,9 +678,13 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
             content_type="application/json",
         )
         # Add the file
-        data.add_field("file", BytesIO(file_content))
+        data.add_field(
+            "file",
+            BytesIO(file_content),
+            filename=file_name,
+            content_type=file_content_type,
+        )
 
-        url = "/api/v0/storage/add_file"
         logger.debug(f"Posting file on {url}")
 
         async with self.http_session.post(url, data=data) as resp:
@@ -685,7 +721,8 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
             payment=payment,
             **(extra_fields or {}),
         )
-        message, _ = await self._storage_push_file_with_message(
+        message, _ = await self._push_file_with_message(
+            url="/api/v0/storage/add_file",
             file_content=file_content,
             store_content=store_content,
             channel=channel,
@@ -695,5 +732,124 @@ class AuthenticatedAlephHttpClient(AlephHttpClient, AuthenticatedAlephClient):
         # Some nodes may not implement authenticated file upload yet. As we cannot detect
         # this easily, broadcast the message a second time to ensure publication on older
         # nodes.
+        _, status = await self._broadcast(message=message, sync=sync)
+        return message, status
+
+    async def _upload_file_ipfs(
+        self,
+        address: str,
+        file_content: bytes,
+        guess_mime_type: bool = False,
+        ref: Optional[str] = None,
+        extra_fields: Optional[dict] = None,
+        channel: Optional[str] = settings.DEFAULT_CHANNEL,
+        sync: bool = False,
+        payment: Optional[Payment] = None,
+    ) -> Tuple[StoreMessage, MessageStatus]:
+        """Authenticated IPFS upload: compute the CID locally (kubo-default
+        CIDv0, matching what the node will assign), then upload the file and
+        the signed STORE message in a single request."""
+        file_hash = aleph_cid.compute_cid(file_content)
+        if magic and guess_mime_type:
+            mime_type = magic.from_buffer(file_content, mime=True)
+        else:
+            mime_type = None
+
+        store_content = StoreContent(
+            address=address,
+            ref=ref,
+            item_type=ItemType.ipfs,
+            item_hash=ItemHash(file_hash),
+            mime_type=mime_type,  # type: ignore
+            time=time.time(),
+            payment=payment,
+            **(extra_fields or {}),
+        )
+        message, _ = await self._push_file_with_message(
+            url="/api/v0/ipfs/add_file",
+            file_content=file_content,
+            store_content=store_content,
+            channel=channel,
+            sync=sync,
+        )
+
+        # Some nodes may not implement authenticated file upload yet. As we cannot detect
+        # this easily, broadcast the message a second time to ensure publication on older
+        # nodes.
+        _, status = await self._broadcast(message=message, sync=sync)
+        return message, status
+
+    async def create_store_folder(
+        self,
+        folder_path: Union[str, Path],
+        address: Optional[str] = None,
+        ref: Optional[str] = None,
+        extra_fields: Optional[dict] = None,
+        channel: Optional[str] = settings.DEFAULT_CHANNEL,
+        sync: bool = False,
+        payment: Optional[Payment] = None,
+    ) -> Tuple[StoreMessage, MessageStatus]:
+        """
+        Upload a folder to IPFS as a UnixFS directory and create a STORE
+        message for its root CID, in a single authenticated request.
+
+        The folder is packed locally into a CARv1 file (with the same root
+        CID that kubo would assign, CIDv1) and posted to
+        /api/v0/ipfs/add_car together with the signed STORE message.
+
+        Requires the `aleph-cid` package and a node exposing
+        /api/v0/ipfs/add_car.
+
+        :param folder_path: Path to the folder to upload
+        :param address: Address to use or None to use the account address
+        :param ref: A reference to a previous message
+        :param extra_fields: Extra fields to add to the STORE message content
+        :param channel: Channel to use
+        :param sync: If true, waits for the message to be processed by the API server
+        :param payment: Payment method used to pay for the storage
+        """
+        if aleph_cid is None:
+            raise RuntimeError(
+                "Folder uploads require the 'aleph-cid' package: pip install aleph-cid"
+            )
+
+        folder_path = Path(folder_path)
+        if not folder_path.is_dir():
+            raise ValueError(f"Not a directory: {folder_path}")
+
+        address = address or settings.ADDRESS_TO_USE or self.account.get_address()
+        payment = payment or Payment(
+            chain=Chain.ETH, type=PaymentType.hold, receiver=None
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            car_path = Path(tmp_dir) / "upload.car"
+            # CAR packing reads the whole folder; run it off the event loop.
+            root_cid = await asyncio.to_thread(
+                aleph_cid.write_folder_car, folder_path, car_path
+            )
+            car_content = car_path.read_bytes()
+
+        store_content = StoreContent(
+            address=address,
+            ref=ref,
+            item_type=ItemType.ipfs,
+            item_hash=ItemHash(root_cid),
+            time=time.time(),
+            payment=payment,
+            **(extra_fields or {}),
+        )
+        message, status = await self._push_file_with_message(
+            url="/api/v0/ipfs/add_car",
+            file_content=car_content,
+            store_content=store_content,
+            channel=channel,
+            sync=sync,
+            file_name="upload.car",
+            file_content_type="application/vnd.ipld.car",
+        )
+
+        # Mirror the file upload paths: broadcast the message a second time to
+        # ensure publication on nodes that do not process the metadata part.
         _, status = await self._broadcast(message=message, sync=sync)
         return message, status

--- a/tests/unit/test_authenticated_ipfs_upload.py
+++ b/tests/unit/test_authenticated_ipfs_upload.py
@@ -6,7 +6,6 @@ kubo (v0.30.0): the same fixtures must produce the same CIDs here.
 
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock
 
 import aleph_cid
 import pytest
@@ -75,26 +74,6 @@ async def test_create_store_ipfs_authenticated(mock_session_with_post_success):
     assert metadata["sync"] is False
     assert metadata["message"]["signature"] == message.signature
     assert json.loads(metadata["message"]["item_content"])["item_hash"] == expected_cid
-
-
-@pytest.mark.asyncio
-async def test_create_store_ipfs_falls_back_without_aleph_cid(
-    mock_session_with_post_success, monkeypatch
-):
-    monkeypatch.setattr("aleph.sdk.client.authenticated_http.aleph_cid", None)
-    mock_ipfs_push_file = AsyncMock()
-    mock_ipfs_push_file.return_value = GOLDEN_EMPTY_FILE_V0
-    mock_session_with_post_success.ipfs_push_file = mock_ipfs_push_file
-
-    async with mock_session_with_post_success as session:
-        message, _ = await session.create_store(
-            file_content=b"",
-            channel="TEST",
-            storage_engine=StorageEnum.ipfs,
-        )
-
-    mock_ipfs_push_file.assert_called_once()
-    assert message.content.item_hash == GOLDEN_EMPTY_FILE_V0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_authenticated_ipfs_upload.py
+++ b/tests/unit/test_authenticated_ipfs_upload.py
@@ -1,0 +1,143 @@
+"""Tests for authenticated IPFS uploads (client-side CID computation).
+
+Golden CIDs come from the aleph-cid test suite, which pins them against real
+kubo (v0.30.0): the same fixtures must produce the same CIDs here.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import aleph_cid
+import pytest
+from aleph_message.models import ItemType, StoreMessage
+from aleph_message.status import MessageStatus
+
+from aleph.sdk.types import StorageEnum
+
+# kubo `ipfs add` of an empty file (CIDv0)
+GOLDEN_EMPTY_FILE_V0 = "QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH"
+# kubo /api/v0/add?wrap-with-directory=true of the nested fixture below (CIDv1)
+GOLDEN_NESTED_DIR_V1 = "bafybeidcclyz24mrl4furbaf4ecb3ks52dbfer7r6dxqavd4wrqg7bp7lu"
+
+
+def fixture_nested_dir(root: Path):
+    (root / "top.txt").write_bytes(b"top\n")
+    sub = root / "sub"
+    sub.mkdir()
+    (sub / "inner.txt").write_bytes(b"inner\n")
+    deeper = sub / "deeper"
+    deeper.mkdir()
+    (deeper / "leaf.txt").write_bytes(b"leaf\n")
+
+
+def posted_form_fields(http_session, url: str) -> dict:
+    """Return {field_name: (headers, value)} of the multipart form posted to `url`."""
+    for call in http_session.post.call_args_list:
+        if call.args and call.args[0] == url:
+            form = call.kwargs["data"]
+            return {
+                type_options["name"]: (headers, value)
+                for type_options, headers, value in form._fields
+            }
+    raise AssertionError(f"No POST to {url}")
+
+
+def test_golden_cid_vector():
+    assert aleph_cid.compute_cid(b"") == GOLDEN_EMPTY_FILE_V0
+
+
+@pytest.mark.asyncio
+async def test_create_store_ipfs_authenticated(mock_session_with_post_success):
+    content = b"Test authenticated ipfs upload\n"
+    expected_cid = aleph_cid.compute_cid(content)
+    assert expected_cid.startswith("Qm")
+
+    async with mock_session_with_post_success as session:
+        message, status = await session.create_store(
+            file_content=content,
+            channel="TEST",
+            storage_engine=StorageEnum.ipfs,
+        )
+
+    assert isinstance(message, StoreMessage)
+    assert status == MessageStatus.PENDING
+    assert message.content.item_type == ItemType.ipfs
+    assert message.content.item_hash == expected_cid
+    assert message.signature
+
+    # The file and the signed message must travel in one multipart request.
+    fields = posted_form_fields(
+        mock_session_with_post_success.http_session, "/api/v0/ipfs/add_file"
+    )
+    assert fields["file"][1].read() == content
+    metadata = json.loads(fields["metadata"][1])
+    assert metadata["sync"] is False
+    assert metadata["message"]["signature"] == message.signature
+    assert json.loads(metadata["message"]["item_content"])["item_hash"] == expected_cid
+
+
+@pytest.mark.asyncio
+async def test_create_store_ipfs_falls_back_without_aleph_cid(
+    mock_session_with_post_success, monkeypatch
+):
+    monkeypatch.setattr("aleph.sdk.client.authenticated_http.aleph_cid", None)
+    mock_ipfs_push_file = AsyncMock()
+    mock_ipfs_push_file.return_value = GOLDEN_EMPTY_FILE_V0
+    mock_session_with_post_success.ipfs_push_file = mock_ipfs_push_file
+
+    async with mock_session_with_post_success as session:
+        message, _ = await session.create_store(
+            file_content=b"",
+            channel="TEST",
+            storage_engine=StorageEnum.ipfs,
+        )
+
+    mock_ipfs_push_file.assert_called_once()
+    assert message.content.item_hash == GOLDEN_EMPTY_FILE_V0
+
+
+@pytest.mark.asyncio
+async def test_create_store_folder(mock_session_with_post_success, tmp_path):
+    folder = tmp_path / "site"
+    folder.mkdir()
+    fixture_nested_dir(folder)
+
+    async with mock_session_with_post_success as session:
+        message, status = await session.create_store_folder(
+            folder_path=folder,
+            channel="TEST",
+        )
+
+    assert isinstance(message, StoreMessage)
+    assert status == MessageStatus.PENDING
+    assert message.content.item_type == ItemType.ipfs
+    assert message.content.item_hash == GOLDEN_NESTED_DIR_V1
+    assert message.signature
+
+    fields = posted_form_fields(
+        mock_session_with_post_success.http_session, "/api/v0/ipfs/add_car"
+    )
+    metadata = json.loads(fields["metadata"][1])
+    assert (
+        json.loads(metadata["message"]["item_content"])["item_hash"]
+        == GOLDEN_NESTED_DIR_V1
+    )
+
+    # The uploaded CAR must be a valid CARv1 whose root is the message CID.
+    car_headers, car_value = fields["file"]
+    assert car_headers.get("Content-Type") == "application/vnd.ipld.car"
+    car_file = tmp_path / "roundtrip.car"
+    car_file.write_bytes(car_value.read())
+    assert aleph_cid.read_carv1_root(car_file) == GOLDEN_NESTED_DIR_V1
+
+
+@pytest.mark.asyncio
+async def test_create_store_folder_rejects_files(
+    mock_session_with_post_success, tmp_path
+):
+    not_a_dir = tmp_path / "file.txt"
+    not_a_dir.write_bytes(b"x")
+    async with mock_session_with_post_success as session:
+        with pytest.raises(ValueError):
+            await session.create_store_folder(folder_path=not_a_dir)


### PR DESCRIPTION
Step 3 of the parity plan with the Rust SDK: authenticated IPFS uploads, with CIDs computed client-side via the new [`aleph-cid`](https://pypi.org/project/aleph-cid/) package (PyO3 bindings over the Rust reference implementation, see aleph-im/aleph-rs#263).

## What changes

- **`create_store(storage_engine=StorageEnum.ipfs)`** no longer does the legacy two-step (unauthenticated `ipfs_push_file`, then `POST /messages`). It now mirrors the storage engine path: compute the kubo-default CIDv0 locally, sign the STORE message, and send file + message in one multipart request to `/api/v0/ipfs/add_file`. Same double-broadcast safety net as the native path for older nodes.
- **New `create_store_folder(folder_path, ...)`**: packs a folder into a CARv1 file locally (UnixFS DAG with the exact root CIDv1 kubo would assign, HAMT sharding included) and posts it with the signed message to `/api/v0/ipfs/add_car`. CAR packing runs off the event loop via `asyncio.to_thread` (the Rust hasher releases the GIL).
- `_storage_push_file_with_message` generalized to `_push_file_with_message(url, ...)` with optional file name and content type; the storage path uses it unchanged.
- `aleph-cid>=0.1` added as a required dependency (abi3 wheels for CPython 3.10+ on Linux x86_64/aarch64, macOS, Windows; sdist builds from source elsewhere). It is imported unconditionally: it has no system-library component, so if pip resolved the SDK, the import works. The legacy unauthenticated `ipfs_push_file` method remains available as public API.

## Tests

`tests/unit/test_authenticated_ipfs_upload.py` (step 4 of the plan, golden parity):

- `compute_cid(b"")` pinned to the kubo golden `QmbFMke1...AwQH`.
- Authenticated file upload: asserts the multipart request carries the file and the signed message, and that `item_content.item_hash` is the locally computed CIDv0.
- Folder upload: nested-directory fixture pinned to the kubo golden root `bafybeidcclyz...`, and the posted CAR is read back with `read_carv1_root` to confirm header root == message CID.
- Rejection of non-directories for folder uploads.

All pass; the rest of the unit suite is unchanged vs main (the pre-existing `test_vm_client.py` failures with latest aiohttp + aioresponses 0.7.6 are unrelated). ruff, black, isort, pyproject-fmt, and mypy are clean on the changed files.

## Notes for reviewers

- The CIDs this produces are verified against the same kubo v0.30.0 golden vectors as the Rust SDK, so a STORE message for a given file or folder now has the identical `item_hash` regardless of which SDK created it.
- `/api/v0/ipfs/add_car` requires a CCN that exposes it; `create_store` itself stays compatible with older nodes via the second broadcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
