### PR TITLE
fix(ci): pin aiohttp<3.13 in the testing env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,9 @@ envs.testing.dependencies = [
   "pytest-mock==3.12.0",
   "pytest-asyncio==0.23.5",
   "pytest-aiohttp==1.0.5",
+  # aiohttp 3.13 changed ClientResponse.__init__ (new stream_writer kwarg),
+  # which aioresponses (up to 0.7.8) cannot mock. Test-only pin.
+  "aiohttp<3.13",
   "aioresponses==0.7.6",
   "fastapi",
   "httpx",


### PR DESCRIPTION
Main CI (and every PR) has been red for at least 5 days: the 23 vm client test failures are aiohttp 3.13+ changing ClientResponse.__init__ (new stream_writer kwarg), which aioresponses cannot mock, including the latest 0.7.8.

Verified locally: with aiohttp 3.14 + aioresponses 0.7.6 or 0.7.8 the 23 tests fail; with aiohttp 3.12.15 all 32 vm tests pass.

This pins aiohttp<3.13 in the hatch testing env only. The runtime requirement stays aiohttp>=3.8.3. The pin can be dropped once aioresponses supports aiohttp 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
